### PR TITLE
fix: filter looping playlists by default to match upstream BDInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Notes:
 - `-f, --forumsonly` (only forums paste block)
 - `-s, --summaryonly` (only quick summary block; likely what you want)
 - `-b, --enablessif` (default on; use `--enablessif=false` to disable)
-- `-l, --filterloopingplaylists`
+- `-l, --filterloopingplaylists` (default on; use `--filterloopingplaylists=false` to disable)
 - `-y, --filtershortplaylist` (default on; use `--filtershortplaylist=false` to disable)
 - `-v, --filtershortplaylistvalue` (seconds)
 - `-k, --keepstreamorder`

--- a/cmd/bdinfo/main.go
+++ b/cmd/bdinfo/main.go
@@ -121,7 +121,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&opts.autoSaveReport, "autosavereport", "a", false, "Auto save report (compat)")
 	// No short flag: `-f` is already used by `--forumsonly` in this CLI.
 	rootCmd.Flags().BoolVar(&opts.generateFrameData, "generateframedatafile", false, "Generate frame data file (compat)")
-	rootCmd.Flags().BoolVarP(&opts.filterLooping, "filterloopingplaylists", "l", false, "Filter looping playlists")
+	rootCmd.Flags().BoolVarP(&opts.filterLooping, "filterloopingplaylists", "l", false, "Filter looping playlists (default on; use --filterloopingplaylists=false to disable)")
 	rootCmd.Flags().BoolVarP(&opts.filterShort, "filtershortplaylist", "y", false, "Filter short playlists (default on; use --filtershortplaylist=false to disable)")
 	rootCmd.Flags().IntVarP(&opts.filterShortValue, "filtershortplaylistvalue", "v", 20, "Short playlist length threshold in seconds")
 	rootCmd.Flags().BoolVarP(&opts.useImagePrefix, "useimageprefix", "i", false, "Use image prefix (compat)")

--- a/internal/bdrom/playlist_loop_test.go
+++ b/internal/bdrom/playlist_loop_test.go
@@ -1,0 +1,43 @@
+package bdrom
+
+import (
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/settings"
+)
+
+// Covers the loop-detection + IsValid gating mechanism behind issue #13:
+// Initialize() flags a playlist as looping when the same source clip is
+// referenced at the same TimeIn more than once (a menu/"play-all" loop), and
+// IsValid() then excludes it only when FilterLoopingPlaylists is enabled.
+func TestPlaylistFile_HasLoopsGatesIsValid(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+
+	// Same clip referenced twice at the same TimeIn = a loop. Total length (30s)
+	// clears the short-playlist threshold so only the loop filter is in play.
+	pl := &PlaylistFile{
+		Name:     "00001.MPLS",
+		Settings: cfg,
+		StreamClips: []*StreamClip{
+			{AngleIndex: 0, Name: "00100.M2TS", TimeIn: 0, Length: 15},
+			{AngleIndex: 0, Name: "00100.M2TS", TimeIn: 0, Length: 15},
+		},
+	}
+	pl.Initialize()
+
+	if !pl.HasLoops {
+		t.Fatalf("expected HasLoops=true for a clip repeated at the same TimeIn")
+	}
+
+	cfg.FilterLoopingPlaylists = true
+	pl.Settings = cfg
+	if pl.IsValid() {
+		t.Fatalf("expected IsValid()=false for a looping playlist when FilterLoopingPlaylists=true")
+	}
+
+	cfg.FilterLoopingPlaylists = false
+	pl.Settings = cfg
+	if !pl.IsValid() {
+		t.Fatalf("expected IsValid()=true for the same playlist when FilterLoopingPlaylists=false")
+	}
+}

--- a/internal/report/report_main_test.go
+++ b/internal/report/report_main_test.go
@@ -1,0 +1,48 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/bdrom"
+	"github.com/autobrr/go-bdinfo/internal/settings"
+)
+
+// Regression test for issue #13: `--main` selected a looping menu/"play-all"
+// playlist because its loop-inflated length beat the real feature. Upstream
+// BDInfo filters looping playlists by default; go-bdinfo must too. With default
+// settings, selectMainPlaylist must drop the HasLoops playlist and return the
+// real feature even though the menu playlist reports a longer total length.
+func TestSelectMainPlaylist_SkipsLoopingMenuByDefault(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+	cfg.MainPlaylistOnly = true
+
+	// Looping menu playlist: loop-inflated total length (longest) but HasLoops.
+	menu := &bdrom.PlaylistFile{
+		Name:          "01000.MPLS",
+		IsInitialized: true,
+		HasLoops:      true,
+		Settings:      cfg,
+		StreamClips: []*bdrom.StreamClip{
+			{AngleIndex: 0, Length: 13558.545, PacketCount: 100_000},
+		},
+	}
+	// Real feature: shorter runtime, legitimate (no loops).
+	feature := &bdrom.PlaylistFile{
+		Name:          "00800.MPLS",
+		IsInitialized: true,
+		HasLoops:      false,
+		Settings:      cfg,
+		StreamClips: []*bdrom.StreamClip{
+			{AngleIndex: 0, Length: 5113.233, PacketCount: 1_000_000},
+		},
+	}
+
+	got := selectMainPlaylist([]*bdrom.PlaylistFile{menu, feature}, cfg)
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one main playlist, got %d", len(got))
+	}
+	if got[0].Name != "00800.MPLS" {
+		t.Fatalf("expected feature 00800.MPLS as main, got looping menu %s", got[0].Name)
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -78,6 +78,7 @@ func TestWriteReport_StreamDiagnosticsHiddenStreamsLast(t *testing.T) {
 	playlist := &bdrom.PlaylistFile{
 		Name:            "00001.MPLS",
 		Settings:        cfg,
+		IsInitialized:   true,
 		HasHiddenTracks: true,
 		Streams: map[uint16]stream.Info{
 			0x1011: primaryVideo,
@@ -85,12 +86,14 @@ func TestWriteReport_StreamDiagnosticsHiddenStreamsLast(t *testing.T) {
 			0x1100: audio,
 			0x12A0: graphics,
 		},
+		// Length must clear the short-playlist threshold (20s) so the playlist is
+		// valid; the default now filters short/looping playlists like upstream.
 		StreamClips: []*bdrom.StreamClip{
 			{
 				Settings:    cfg,
 				Name:        "00007.M2TS",
-				Length:      10.0,
-				PacketCount: 11_600,
+				Length:      30.0,
+				PacketCount: 34_800,
 				StreamFile:  streamFile,
 			},
 		},

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -28,7 +28,7 @@ func Default(reportBaseDir string) Settings {
 		ExtendedStreamDiagnostics: false,
 		EnableSSIF:                true,
 		BigPlaylistOnly:           false,
-		FilterLoopingPlaylists:    false,
+		FilterLoopingPlaylists:    true,
 		FilterShortPlaylists:      true,
 		FilterShortPlaylistsVal:   20,
 		KeepStreamOrder:           false,


### PR DESCRIPTION
`--main` could select a looping menu/"play-all" playlist instead of the feature, because go-bdinfo defaulted `FilterLoopingPlaylists` to `false` while upstream BDInfo (and the official binary) default it to `true`. With the filter off, a looping playlist's loop-inflated length wins the "longest playlist" heuristic. Verified against a real disc with the official BDInfo 2.0.5 binary: `--main` picked a 3:45:58 menu playlist (`01000.MPLS`) over the real 1:25:13 feature (`00800.MPLS`); the official binary excludes the menu playlist entirely by default.

This flips the default to `true` so looping playlists are excluded from candidacy across `--main`, summary, and full reports — matching the official binary byte-for-byte on the test disc. `--filterloopingplaylists=false` still opts back in. The parity test derives both binaries' flags from `settings.Default()`, so they stay in sync. Adds regression coverage for `selectMainPlaylist` and the `HasLoops`/`IsValid` gating.

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help text and README documentation clarifying that looping playlist filtering is enabled by default and can be disabled as needed

* **Chores**
  * Default setting now enables looping playlist filtering

* **Tests**
  * Added tests verifying loop detection and filtering behavior during playlist selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->