### PR TITLE
fix: report sane size for looping playlists

### DIFF
--- a/internal/bdrom/playlist.go
+++ b/internal/bdrom/playlist.go
@@ -82,9 +82,46 @@ func NewCustomPlaylist(name string, clips []*StreamClip, settings settings.Setti
 	return pl
 }
 
+// clipRefKey identifies a physically-identical clip reference: same source file
+// and same in/out point (and angle). A looping menu/"play-all" playlist references
+// the exact same clip many times; for byte accounting we count each unique clip
+// once instead of once per loop iteration, otherwise Size/Total Bitrate balloon far
+// past the disc size (issue #16). Length is intentionally NOT de-duplicated -- the
+// playlist genuinely plays that long, matching upstream BDInfo.
+//
+// This deliberately diverges from upstream BDInfo (which sums bytes per iteration).
+// For non-looping playlists no references collide, so behavior is unchanged.
+type clipRefKey struct {
+	name    string
+	timeIn  float64
+	timeOut float64
+	angle   int
+}
+
+func newClipRefKey(clip *StreamClip) clipRefKey {
+	return clipRefKey{name: clip.Name, timeIn: clip.TimeIn, timeOut: clip.TimeOut, angle: clip.AngleIndex}
+}
+
+// uniqueClipRefs returns the playlist's clips with looping repetitions collapsed:
+// only the first reference of each physically-identical clip (see clipRefKey) is
+// kept. Order is preserved. Used for byte/size accounting, not length.
+func (p *PlaylistFile) uniqueClipRefs() []*StreamClip {
+	seen := make(map[clipRefKey]struct{}, len(p.StreamClips))
+	unique := make([]*StreamClip, 0, len(p.StreamClips))
+	for _, clip := range p.StreamClips {
+		key := newClipRefKey(clip)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, clip)
+	}
+	return unique
+}
+
 func (p *PlaylistFile) FileSize() uint64 {
 	var size uint64
-	for _, clip := range p.StreamClips {
+	for _, clip := range p.uniqueClipRefs() {
 		size += clip.FileSize
 	}
 	return size
@@ -92,7 +129,7 @@ func (p *PlaylistFile) FileSize() uint64 {
 
 func (p *PlaylistFile) InterleavedFileSize() uint64 {
 	var size uint64
-	for _, clip := range p.StreamClips {
+	for _, clip := range p.uniqueClipRefs() {
 		size += clip.InterleavedFileSize
 	}
 	return size
@@ -118,7 +155,7 @@ func (p *PlaylistFile) TotalAngleLength() float64 {
 
 func (p *PlaylistFile) TotalSize() uint64 {
 	var size uint64
-	for _, clip := range p.StreamClips {
+	for _, clip := range p.uniqueClipRefs() {
 		if clip.AngleIndex == 0 {
 			size += clip.PacketSize()
 		}
@@ -128,7 +165,7 @@ func (p *PlaylistFile) TotalSize() uint64 {
 
 func (p *PlaylistFile) TotalAngleSize() uint64 {
 	var size uint64
-	for _, clip := range p.StreamClips {
+	for _, clip := range p.uniqueClipRefs() {
 		size += clip.PacketSize()
 	}
 	return size

--- a/internal/bdrom/playlist_loop_size_test.go
+++ b/internal/bdrom/playlist_loop_size_test.go
@@ -1,0 +1,96 @@
+package bdrom
+
+import (
+	"math"
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/settings"
+)
+
+// Issue #16: a looping menu/"play-all" playlist references the same physical clip
+// (same file + in/out point) many times. Length is genuinely the sum of every
+// reference, but Size must count each unique clip once -- otherwise the reported
+// Size/Total Bitrate balloon far past the disc (e.g. 31.9 GB for 88 MB of content).
+//
+// This deliberately diverges from upstream BDInfo (which sums bytes once per loop
+// iteration); the divergence only surfaces when looping playlists are shown, which
+// is opt-in via --filterloopingplaylists=false.
+func TestPlaylistFile_LoopingSizeCountsUniqueClipOnce(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+
+	// 300 references to the exact same clip (same name + in/out): a loop.
+	const refs = 300
+	clips := make([]*StreamClip, 0, refs)
+	for range refs {
+		clips = append(clips, &StreamClip{
+			Settings:    cfg,
+			AngleIndex:  0,
+			Name:        "01010.M2TS",
+			TimeIn:      11.651,
+			TimeOut:     56.696,
+			Length:      45.045,
+			PacketCount: 1000,
+			FileSize:    500,
+		})
+	}
+	pl := &PlaylistFile{Name: "01000.MPLS", Settings: cfg, StreamClips: clips}
+
+	// Length is the honest sum of every reference (unchanged from upstream).
+	wantLen := 45.045 * refs
+	if got := pl.TotalLength(); math.Abs(got-wantLen) > 1e-6 {
+		t.Errorf("TotalLength() = %v, want %v (length must stay summed)", got, wantLen)
+	}
+
+	// Size counts the unique clip exactly once: 1000 packets * 192.
+	const wantSize = 1000 * 192
+	if got := pl.TotalSize(); got != wantSize {
+		t.Errorf("TotalSize() = %d, want %d (each unique clip counted once)", got, wantSize)
+	}
+
+	// FileSize is likewise de-duplicated to the single physical clip.
+	if got := pl.FileSize(); got != 500 {
+		t.Errorf("FileSize() = %d, want 500 (de-duplicated)", got)
+	}
+
+	// Total Bitrate derives from the de-duplicated size, so it is sane (not inflated).
+	wantBitrate := uint64(float64(wantSize) * 8.0 / wantLen)
+	if got := pl.TotalBitRate(); got != wantBitrate {
+		t.Errorf("TotalBitRate() = %d, want %d", got, wantBitrate)
+	}
+}
+
+// A normal playlist (distinct clips) must be completely unaffected by the de-dup.
+func TestPlaylistFile_NonLoopingSizeUnchanged(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+	pl := &PlaylistFile{
+		Name:     "00800.MPLS",
+		Settings: cfg,
+		StreamClips: []*StreamClip{
+			{Settings: cfg, AngleIndex: 0, Name: "00800.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, PacketCount: 1000, FileSize: 500},
+			{Settings: cfg, AngleIndex: 0, Name: "00801.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, PacketCount: 2000, FileSize: 700},
+		},
+	}
+	if got, want := pl.TotalSize(), uint64((1000+2000)*192); got != want {
+		t.Errorf("TotalSize() = %d, want %d (distinct clips all counted)", got, want)
+	}
+	if got, want := pl.FileSize(), uint64(500+700); got != want {
+		t.Errorf("FileSize() = %d, want %d", got, want)
+	}
+}
+
+// Two references to the SAME file but DIFFERENT in/out points are distinct content
+// (not a loop) and must both be counted.
+func TestPlaylistFile_SameFileDifferentSegmentsBothCounted(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+	pl := &PlaylistFile{
+		Name:     "00500.MPLS",
+		Settings: cfg,
+		StreamClips: []*StreamClip{
+			{Settings: cfg, AngleIndex: 0, Name: "00500.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, PacketCount: 1000},
+			{Settings: cfg, AngleIndex: 0, Name: "00500.M2TS", TimeIn: 20, TimeOut: 30, Length: 10, PacketCount: 1000},
+		},
+	}
+	if got, want := pl.TotalSize(), uint64((1000+1000)*192); got != want {
+		t.Errorf("TotalSize() = %d, want %d (different segments both counted)", got, want)
+	}
+}


### PR DESCRIPTION
A looping menu/"play-all" playlist references the exact same physical clip many times, and summing each reference's bytes inflated a playlist's `Size`/`Total Bitrate` far past the disc — e.g. `01000.MPLS` on *The Naked Gun (2025)* reported **31.9 GB** for ~106 MB of looped content. This de-duplicates physically-identical clip references (same file + in/out point + angle) in byte accounting (`TotalSize`/`TotalAngleSize`/`FileSize`/`InterleavedFileSize`), so each unique clip is counted once (~106 MB). Length is intentionally left summed, since the playlist genuinely plays that long.

Note this **deliberately diverges** from upstream BDInfo, which inflates identically (verified against the official v2.0.5 and 0.8.0.0 binaries on a real disc — the "88 MB" cited in the issue was a quick-scan artifact, not the official full-scan output). The divergence only surfaces with `--filterloopingplaylists=false`; with looping playlists filtered by default the report is byte-identical to before. Closes #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playlist file size calculations that were double-counting identical clip references used multiple times in playlists. This correction improves the accuracy of derived bitrate calculations as well.

* **Tests**
  * Added tests validating correct playlist sizing behavior for looping playlists with repeated clips, non-looping playlists, and scenarios with the same file referenced at different segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->