### PR TITLE
perf(scan): replace per-packet seen-PID map with a bounded array

### DIFF
--- a/internal/bdrom/streamfile.go
+++ b/internal/bdrom/streamfile.go
@@ -648,7 +648,11 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 		}
 	}
 	var unknownState *streamState
-	seenStreamOrder := make(map[uint16]struct{}, len(s.Streams))
+	// seenByPID tracks which PIDs have been recorded into scanStreamOrder. A bounded
+	// array (PID is 13-bit, < maxTSPID) instead of a map: this lookup runs once per TS
+	// packet — hundreds of millions of times on a feature scan — so the map's per-packet
+	// hash dominated CPU (~22% of scan CPU in profiling). Result order is unchanged.
+	var seenByPID [maxTSPID]bool
 	scanStreamOrder := make([]uint16, 0, len(s.Streams))
 	pmtStreamOrder := append([]uint16(nil), initialPMTOrder...)
 	defer func() {
@@ -687,8 +691,8 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 		}
 		known := st != nil
 		if known {
-			if _, ok := seenStreamOrder[pid]; !ok {
-				seenStreamOrder[pid] = struct{}{}
+			if !seenByPID[pidIdx] {
+				seenByPID[pidIdx] = true
 				scanStreamOrder = append(scanStreamOrder, pid)
 			}
 		}


### PR DESCRIPTION
Replaces the per-packet `seenStreamOrder` map with a `[maxTSPID]bool` array. Profiling a 92 GB HEVC UHD scan showed this map's hashing at ~22% of total scan CPU (~44% of non-I/O parse CPU) — it's checked once per TS packet, hundreds of millions of times on a feature scan. PID is a 13-bit value and is already indexed by arrays elsewhere in the same loop (`stateByPID`/`streamByPID`), so this is a drop-in. `scanStreamOrder` is populated in the identical order, so report output is byte-identical — verified `cmp`-exact on real AVC, DTS-HD MA, TrueHD/Atmos and HEVC discs, plus the unit suite and `-race` pass.

Parser CPU (`processPacket`) drops ~44% (26.4s → 14.8s on the UHD scan) and the map-hash functions disappear from the profile. Real-disc scans on typical storage stay I/O-bound (~96% of raw disk throughput), so wall-time there is unchanged; the win shows on fast/cached storage and as lower CPU load. Profiling context and a parser-CPU roadmap are in #19.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal performance optimization for stream processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->