### PR TITLE
perf(scan): cache active stream states to skip per-flush map range

### DIFF
--- a/internal/bdrom/streamfile.go
+++ b/internal/bdrom/streamfile.go
@@ -391,7 +391,13 @@ type scanClipTarget struct {
 // activeStreamEntry is a precomputed view of a scan's per-PID stream states, used
 // by the per-flush bitrate update. Building this slice once lets updateStreamBitrates
 // iterate active states without ranging the states map (and re-hashing s.Streams) on
-// every video DTS flush. isVideo is cached at build time.
+// every video DTS flush.
+//
+// isVideo is cached at build time, which makes "a stream's video-ness does not change
+// between the cache build and the bitrate flushes" a load-bearing invariant: it holds
+// today because s.Streams membership is fixed before the build and no StreamType
+// mutation runs during the scan loop. A future change that refines a stream's codec
+// mid-scan must rebuild or update this cache, or the wrong stream will be video-skipped.
 type activeStreamEntry struct {
 	pid     uint16
 	state   *streamState

--- a/internal/bdrom/streamfile.go
+++ b/internal/bdrom/streamfile.go
@@ -388,6 +388,16 @@ type scanClipTarget struct {
 	streams map[uint16]stream.Info
 }
 
+// activeStreamEntry is a precomputed view of a scan's per-PID stream states, used
+// by the per-flush bitrate update. Building this slice once lets updateStreamBitrates
+// iterate active states without ranging the states map (and re-hashing s.Streams) on
+// every video DTS flush. isVideo is cached at build time.
+type activeStreamEntry struct {
+	pid     uint16
+	state   *streamState
+	isVideo bool
+}
+
 // clipTargetCursor narrows clip-target scans to time-overlapping clips while
 // preserving original target iteration order for deterministic updates.
 type clipTargetCursor struct {
@@ -619,14 +629,17 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 	}
 
 	states := make(map[uint16]*streamState, len(s.Streams)+1)
+	activeStates := make([]activeStreamEntry, 0, len(s.Streams)+1)
 	var stateByPID [maxTSPID]*streamState
 	var streamByPID [maxTSPID]stream.Info
 	for pid, st := range s.Streams {
 		dataCap := maxStreamDataOther
+		isVideo := false
 		if st != nil {
 			switch {
 			case st.Base().IsVideoStream():
 				dataCap = maxStreamDataVideo
+				isVideo = true
 			case st.Base().IsAudioStream():
 				dataCap = maxStreamDataAudio
 			}
@@ -637,6 +650,7 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 			collectDiagnostics: collectDiagnostics,
 		}
 		states[pid] = state
+		activeStates = append(activeStates, activeStreamEntry{pid: pid, state: state, isVideo: isVideo})
 		if int(pid) < maxTSPID {
 			streamByPID[int(pid)] = st
 			stateByPID[int(pid)] = state
@@ -686,6 +700,9 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 			if unknownState == nil {
 				unknownState = &streamState{pesPacketRemaining: -2, collectDiagnostics: collectDiagnostics}
 				states[unknownStatePID] = unknownState
+				// Mirror the map's lazy unknownState entry. isVideo=false matches the
+				// map version's "pid not in s.Streams -> never video-skip" branch.
+				activeStates = append(activeStates, activeStreamEntry{pid: unknownStatePID, state: unknownState, isVideo: false})
 			}
 			state = unknownState
 		}
@@ -795,7 +812,7 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 					}
 				}
 			}
-			s.parsePESHeaderTimestamp(state, isVideo, playlists, clipTargets, clipCursor, states, pid, &firstTS, &lastTS)
+			s.parsePESHeaderTimestamp(state, isVideo, playlists, clipTargets, clipCursor, activeStates, pid, &firstTS, &lastTS)
 		}
 		if len(payload) == 0 {
 			return
@@ -1009,7 +1026,7 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 			ptsLast = state.ptsLast
 			ptsDiff = int64(ptsLast) - int64(state.dtsPrev)
 		}
-		s.updateStreamBitrates(playlists, clipTargets, clipCursor, states, pid, ptsLast, ptsDiff)
+		s.updateStreamBitrates(playlists, clipTargets, clipCursor, activeStates, pid, ptsLast, ptsDiff)
 	}
 
 	for pid, st := range s.Streams {
@@ -1112,7 +1129,7 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 	return nil
 }
 
-func (s *StreamFile) handleTimestamp(playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, states map[uint16]*streamState, pid uint16, state *streamState, ts uint64, dtsForLength uint64, isVideo bool, firstDTS *uint64, lastDTS *uint64) {
+func (s *StreamFile) handleTimestamp(playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, activeStates []activeStreamEntry, pid uint16, state *streamState, ts uint64, dtsForLength uint64, isVideo bool, firstDTS *uint64, lastDTS *uint64) {
 	if ts == 0 {
 		return
 	}
@@ -1120,7 +1137,7 @@ func (s *StreamFile) handleTimestamp(playlists []*PlaylistFile, clipTargets []sc
 		diff := int64(ts) - int64(state.dtsPrev)
 		state.lastDiff = diff
 		if isVideo {
-			s.updateStreamBitrates(playlists, clipTargets, clipCursor, states, pid, ts, diff)
+			s.updateStreamBitrates(playlists, clipTargets, clipCursor, activeStates, pid, ts, diff)
 			// BDInfo computes TSStreamFile.Length using DTS (when present). For PES packets that
 			// only include PTS, BDInfo continues to use the last seen DTS and does not extend
 			// the file duration based on PTS-only timestamps.
@@ -1142,7 +1159,7 @@ func (s *StreamFile) handleTimestamp(playlists []*PlaylistFile, clipTargets []sc
 	state.tsCount++
 }
 
-func (s *StreamFile) parsePESHeaderTimestamp(state *streamState, isVideo bool, playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, states map[uint16]*streamState, pid uint16, firstTS *uint64, lastTS *uint64) {
+func (s *StreamFile) parsePESHeaderTimestamp(state *streamState, isVideo bool, playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, activeStates []activeStreamEntry, pid uint16, firstTS *uint64, lastTS *uint64) {
 	if !isVideo || state.pesHeaderParsed {
 		return
 	}
@@ -1157,7 +1174,7 @@ func (s *StreamFile) parsePESHeaderTimestamp(state *streamState, isVideo bool, p
 			state.ptsLast = pts
 		}
 		// For duration calculation, keep using the last DTS observed for this stream.
-		s.handleTimestamp(playlists, clipTargets, clipCursor, states, pid, state, pts, state.lastDTS, isVideo, firstTS, lastTS)
+		s.handleTimestamp(playlists, clipTargets, clipCursor, activeStates, pid, state, pts, state.lastDTS, isVideo, firstTS, lastTS)
 		state.pesHeaderParsed = true
 	case 3:
 		if len(state.pesHeaderBuf) < 19 {
@@ -1173,26 +1190,30 @@ func (s *StreamFile) parsePESHeaderTimestamp(state *streamState, isVideo bool, p
 		}
 		if dts > 0 {
 			state.lastDTS = dts
-			s.handleTimestamp(playlists, clipTargets, clipCursor, states, pid, state, dts, dts, isVideo, firstTS, lastTS)
+			s.handleTimestamp(playlists, clipTargets, clipCursor, activeStates, pid, state, dts, dts, isVideo, firstTS, lastTS)
 		}
 		state.pesHeaderParsed = true
 	}
 }
 
-func (s *StreamFile) updateStreamBitrates(playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, states map[uint16]*streamState, ptsPID uint16, pts uint64, ptsDiff int64) {
+func (s *StreamFile) updateStreamBitrates(playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, activeStates []activeStreamEntry, ptsPID uint16, pts uint64, ptsDiff int64) {
 	if playlists == nil {
 		return
 	}
-	for pid, state := range states {
+	// Iterate a precomputed slice of active states instead of ranging the states map
+	// (and re-hashing s.Streams) on every video DTS flush. isVideo is cached at build
+	// time; the only non-s.Streams entry (unknownState, PID 0xFFFF) carries isVideo=false,
+	// matching the map version's "pid not in s.Streams -> never video-skip" branch. Per-PID
+	// accumulators are disjoint, so slice order is output-equivalent to the map's random order.
+	for _, e := range activeStates {
+		state := e.state
 		if state.windowPackets == 0 {
 			continue
 		}
-		if base, ok := s.Streams[pid]; ok {
-			if base.Base().IsVideoStream() && pid != ptsPID {
-				continue
-			}
+		if e.isVideo && e.pid != ptsPID {
+			continue
 		}
-		s.updateStreamBitrate(clipTargets, clipCursor, pid, pts, ptsDiff, state)
+		s.updateStreamBitrate(clipTargets, clipCursor, e.pid, pts, ptsDiff, state)
 	}
 }
 

--- a/internal/bdrom/streamfile_bitrate_active_test.go
+++ b/internal/bdrom/streamfile_bitrate_active_test.go
@@ -1,0 +1,189 @@
+package bdrom
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/stream"
+)
+
+// updateStreamBitratesMapRef is a verbatim copy of the pre-optimization map-ranging
+// implementation of updateStreamBitrates. It is kept here purely to differentially
+// validate that the activeStates-slice version visits the same set of (pid, state)
+// entries and produces byte-identical output regardless of iteration order. Map
+// iteration is randomized, so the original code already had to be order-independent;
+// this test pins that property and proves the slice version preserves it.
+func (s *StreamFile) updateStreamBitratesMapRef(playlists []*PlaylistFile, clipTargets []scanClipTarget, clipCursor *clipTargetCursor, states map[uint16]*streamState, ptsPID uint16, pts uint64, ptsDiff int64) {
+	if playlists == nil {
+		return
+	}
+	for pid, state := range states {
+		if state.windowPackets == 0 {
+			continue
+		}
+		if base, ok := s.Streams[pid]; ok {
+			if base.Base().IsVideoStream() && pid != ptsPID {
+				continue
+			}
+		}
+		s.updateStreamBitrate(clipTargets, clipCursor, pid, pts, ptsDiff, state)
+	}
+}
+
+type bitrateSeed struct {
+	pid           uint16
+	known         bool // present in s.Streams (and clip target streams)
+	video         bool
+	windowBytes   uint64
+	windowPackets uint64
+}
+
+func newBitrateStreamInfo(pid uint16, video bool) stream.Info {
+	if video {
+		return &stream.VideoStream{Stream: stream.Stream{PID: pid, StreamType: stream.StreamTypeAVCVideo}}
+	}
+	return &stream.AudioStream{Stream: stream.Stream{PID: pid, StreamType: stream.StreamTypeAC3Audio}}
+}
+
+// buildBitrateWorld constructs an independent StreamFile + clip targets + states from
+// the seeds. Each call returns a fresh, deeply-independent world so the map-ref and
+// slice versions can run side by side without sharing mutable accumulators.
+func buildBitrateWorld(seeds []bitrateSeed) (*StreamFile, []scanClipTarget, map[uint16]*streamState) {
+	s := &StreamFile{
+		Streams:           map[uint16]stream.Info{},
+		StreamDiagnostics: map[uint16][]StreamDiagnostics{},
+	}
+	targetStreams := map[uint16]stream.Info{}
+	states := map[uint16]*streamState{}
+	for _, seed := range seeds {
+		if seed.known {
+			s.Streams[seed.pid] = newBitrateStreamInfo(seed.pid, seed.video)
+			targetStreams[seed.pid] = newBitrateStreamInfo(seed.pid, seed.video)
+		}
+		states[seed.pid] = &streamState{
+			windowBytes:        seed.windowBytes,
+			windowPackets:      seed.windowPackets,
+			streamTag:          "I",
+			collectDiagnostics: true,
+		}
+	}
+	clip := &StreamClip{Name: "00000.m2ts", TimeIn: 0, TimeOut: 1e9}
+	clipTargets := []scanClipTarget{{clip: clip, streams: targetStreams}}
+	return s, clipTargets, states
+}
+
+func activeStatesFromSeeds(seeds []bitrateSeed, states map[uint16]*streamState) []activeStreamEntry {
+	out := make([]activeStreamEntry, 0, len(seeds))
+	for _, seed := range seeds {
+		out = append(out, activeStreamEntry{
+			pid:     seed.pid,
+			state:   states[seed.pid],
+			isVideo: seed.known && seed.video,
+		})
+	}
+	return out
+}
+
+type bitrateSnapshot struct {
+	clipPayload   uint64
+	clipPackets   uint64
+	clipSeconds   float64
+	streamPayload map[uint16]uint64
+	streamPackets map[uint16]uint64
+	streamSeconds map[uint16]float64
+	streamBitrate map[uint16]int64
+	targetPayload map[uint16]uint64
+	targetPackets map[uint16]uint64
+	diagnostics   map[uint16][]StreamDiagnostics
+	windowPackets map[uint16]uint64
+}
+
+func snapshotBitrateWorld(s *StreamFile, clipTargets []scanClipTarget, states map[uint16]*streamState) bitrateSnapshot {
+	snap := bitrateSnapshot{
+		streamPayload: map[uint16]uint64{},
+		streamPackets: map[uint16]uint64{},
+		streamSeconds: map[uint16]float64{},
+		streamBitrate: map[uint16]int64{},
+		targetPayload: map[uint16]uint64{},
+		targetPackets: map[uint16]uint64{},
+		diagnostics:   map[uint16][]StreamDiagnostics{},
+		windowPackets: map[uint16]uint64{},
+	}
+	clip := clipTargets[0].clip
+	snap.clipPayload = clip.PayloadBytes
+	snap.clipPackets = clip.PacketCount
+	snap.clipSeconds = clip.PacketSeconds
+	for pid, info := range s.Streams {
+		b := info.Base()
+		snap.streamPayload[pid] = b.PayloadBytes
+		snap.streamPackets[pid] = b.PacketCount
+		snap.streamSeconds[pid] = b.PacketSeconds
+		snap.streamBitrate[pid] = b.ActiveBitRate
+	}
+	for pid, info := range clipTargets[0].streams {
+		b := info.Base()
+		snap.targetPayload[pid] = b.PayloadBytes
+		snap.targetPackets[pid] = b.PacketCount
+	}
+	for pid, d := range s.StreamDiagnostics {
+		if len(d) > 0 {
+			snap.diagnostics[pid] = d
+		}
+	}
+	for pid, st := range states {
+		snap.windowPackets[pid] = st.windowPackets
+	}
+	return snap
+}
+
+// TestUpdateStreamBitrates_SliceMatchesMap proves the activeStates-slice version of
+// updateStreamBitrates is output-equivalent to the original map-ranging version across
+// every branch (ptsPID video, non-ptsPID video skip, audio, zero-window skip, and an
+// unknown PID not in s.Streams) and independent of iteration order.
+func TestUpdateStreamBitrates_SliceMatchesMap(t *testing.T) {
+	seeds := []bitrateSeed{
+		{pid: 0x1011, known: true, video: true, windowBytes: 4096, windowPackets: 30}, // ptsPID video -> processed
+		{pid: 0x1012, known: true, video: true, windowBytes: 2048, windowPackets: 15}, // other video -> skipped
+		{pid: 0x1100, known: true, video: false, windowBytes: 800, windowPackets: 6},  // audio -> processed
+		{pid: 0x1101, known: true, video: false, windowBytes: 0, windowPackets: 0},    // zero window -> skipped
+		{pid: 0xFFFF, known: false, video: false, windowBytes: 512, windowPackets: 4}, // unknown PID -> clip-only
+	}
+	const ptsPID = uint16(0x1011)
+	const pts = uint64(180000)
+	const ptsDiff = int64(3000)
+	playlists := []*PlaylistFile{} // non-nil so updateStreamBitrates does not short-circuit
+
+	// Reference world: original map-ranging implementation.
+	sRef, ctRef, statesRef := buildBitrateWorld(seeds)
+	sRef.updateStreamBitratesMapRef(playlists, ctRef, nil, statesRef, ptsPID, pts, ptsDiff)
+	want := snapshotBitrateWorld(sRef, ctRef, statesRef)
+
+	// Sanity: the unknown PID and both processed streams must have flowed into the clip
+	// totals (otherwise the test would pass vacuously).
+	if want.clipPayload != 4096+800+512 || want.clipPackets != 30+6+4 {
+		t.Fatalf("reference world clip totals unexpected: payload=%d packets=%d", want.clipPayload, want.clipPackets)
+	}
+
+	// The new slice implementation must match the map reference for every permutation
+	// of the active-states order.
+	perms := [][]int{
+		{0, 1, 2, 3, 4},
+		{4, 3, 2, 1, 0},
+		{2, 4, 0, 3, 1},
+		{1, 3, 0, 4, 2},
+		{3, 0, 4, 2, 1},
+	}
+	for pi, perm := range perms {
+		ordered := make([]bitrateSeed, len(perm))
+		for i, idx := range perm {
+			ordered[i] = seeds[idx]
+		}
+		s2, ct2, states2 := buildBitrateWorld(seeds)
+		active := activeStatesFromSeeds(ordered, states2)
+		s2.updateStreamBitrates(playlists, ct2, nil, active, ptsPID, pts, ptsDiff)
+		got := snapshotBitrateWorld(s2, ct2, states2)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("permutation %d %v: slice impl diverged from map reference\n got=%+v\nwant=%+v", pi, perm, got, want)
+		}
+	}
+}

--- a/internal/bdrom/streamfile_bitrate_active_test.go
+++ b/internal/bdrom/streamfile_bitrate_active_test.go
@@ -94,6 +94,8 @@ type bitrateSnapshot struct {
 	streamBitrate map[uint16]int64
 	targetPayload map[uint16]uint64
 	targetPackets map[uint16]uint64
+	targetSeconds map[uint16]float64
+	targetBitrate map[uint16]int64
 	diagnostics   map[uint16][]StreamDiagnostics
 	windowPackets map[uint16]uint64
 }
@@ -106,6 +108,8 @@ func snapshotBitrateWorld(s *StreamFile, clipTargets []scanClipTarget, states ma
 		streamBitrate: map[uint16]int64{},
 		targetPayload: map[uint16]uint64{},
 		targetPackets: map[uint16]uint64{},
+		targetSeconds: map[uint16]float64{},
+		targetBitrate: map[uint16]int64{},
 		diagnostics:   map[uint16][]StreamDiagnostics{},
 		windowPackets: map[uint16]uint64{},
 	}
@@ -124,6 +128,8 @@ func snapshotBitrateWorld(s *StreamFile, clipTargets []scanClipTarget, states ma
 		b := info.Base()
 		snap.targetPayload[pid] = b.PayloadBytes
 		snap.targetPackets[pid] = b.PacketCount
+		snap.targetSeconds[pid] = b.PacketSeconds
+		snap.targetBitrate[pid] = b.ActiveBitRate
 	}
 	for pid, d := range s.StreamDiagnostics {
 		if len(d) > 0 {
@@ -139,7 +145,9 @@ func snapshotBitrateWorld(s *StreamFile, clipTargets []scanClipTarget, states ma
 // TestUpdateStreamBitrates_SliceMatchesMap proves the activeStates-slice version of
 // updateStreamBitrates is output-equivalent to the original map-ranging version across
 // every branch (ptsPID video, non-ptsPID video skip, audio, zero-window skip, and an
-// unknown PID not in s.Streams) and independent of iteration order.
+// unknown PID not in s.Streams) and independent of iteration order. It runs with both
+// clipCursor==nil (legacy branch) and a non-nil cursor (the branch production always
+// takes), snapshotting the cursor-only target PacketSeconds/ActiveBitRate writes too.
 func TestUpdateStreamBitrates_SliceMatchesMap(t *testing.T) {
 	seeds := []bitrateSeed{
 		{pid: 0x1011, known: true, video: true, windowBytes: 4096, windowPackets: 30}, // ptsPID video -> processed
@@ -153,19 +161,6 @@ func TestUpdateStreamBitrates_SliceMatchesMap(t *testing.T) {
 	const ptsDiff = int64(3000)
 	playlists := []*PlaylistFile{} // non-nil so updateStreamBitrates does not short-circuit
 
-	// Reference world: original map-ranging implementation.
-	sRef, ctRef, statesRef := buildBitrateWorld(seeds)
-	sRef.updateStreamBitratesMapRef(playlists, ctRef, nil, statesRef, ptsPID, pts, ptsDiff)
-	want := snapshotBitrateWorld(sRef, ctRef, statesRef)
-
-	// Sanity: the unknown PID and both processed streams must have flowed into the clip
-	// totals (otherwise the test would pass vacuously).
-	if want.clipPayload != 4096+800+512 || want.clipPackets != 30+6+4 {
-		t.Fatalf("reference world clip totals unexpected: payload=%d packets=%d", want.clipPayload, want.clipPackets)
-	}
-
-	// The new slice implementation must match the map reference for every permutation
-	// of the active-states order.
 	perms := [][]int{
 		{0, 1, 2, 3, 4},
 		{4, 3, 2, 1, 0},
@@ -173,17 +168,48 @@ func TestUpdateStreamBitrates_SliceMatchesMap(t *testing.T) {
 		{1, 3, 0, 4, 2},
 		{3, 0, 4, 2, 1},
 	}
-	for pi, perm := range perms {
-		ordered := make([]bitrateSeed, len(perm))
-		for i, idx := range perm {
-			ordered[i] = seeds[idx]
+
+	// cursorFor returns nil (legacy branch) or a fresh production cursor over the
+	// given world's targets, matching what ScanWithProgress builds.
+	for _, useCursor := range []bool{false, true} {
+		name := "cursor=nil"
+		if useCursor {
+			name = "cursor=production"
 		}
-		s2, ct2, states2 := buildBitrateWorld(seeds)
-		active := activeStatesFromSeeds(ordered, states2)
-		s2.updateStreamBitrates(playlists, ct2, nil, active, ptsPID, pts, ptsDiff)
-		got := snapshotBitrateWorld(s2, ct2, states2)
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("permutation %d %v: slice impl diverged from map reference\n got=%+v\nwant=%+v", pi, perm, got, want)
-		}
+		t.Run(name, func(t *testing.T) {
+			cursorFor := func(ct []scanClipTarget) *clipTargetCursor {
+				if !useCursor {
+					return nil
+				}
+				return newClipTargetCursor(ct)
+			}
+
+			// Reference world: original map-ranging implementation.
+			sRef, ctRef, statesRef := buildBitrateWorld(seeds)
+			sRef.updateStreamBitratesMapRef(playlists, ctRef, cursorFor(ctRef), statesRef, ptsPID, pts, ptsDiff)
+			want := snapshotBitrateWorld(sRef, ctRef, statesRef)
+
+			// Sanity: the unknown PID and both processed streams must have flowed into the
+			// clip totals (otherwise the test would pass vacuously).
+			if want.clipPayload != 4096+800+512 || want.clipPackets != 30+6+4 {
+				t.Fatalf("reference world clip totals unexpected: payload=%d packets=%d", want.clipPayload, want.clipPackets)
+			}
+
+			// The new slice implementation must match the map reference for every
+			// permutation of the active-states order.
+			for pi, perm := range perms {
+				ordered := make([]bitrateSeed, len(perm))
+				for i, idx := range perm {
+					ordered[i] = seeds[idx]
+				}
+				s2, ct2, states2 := buildBitrateWorld(seeds)
+				active := activeStatesFromSeeds(ordered, states2)
+				s2.updateStreamBitrates(playlists, ct2, cursorFor(ct2), active, ptsPID, pts, ptsDiff)
+				got := snapshotBitrateWorld(s2, ct2, states2)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("permutation %d %v: slice impl diverged from map reference\n got=%+v\nwant=%+v", pi, perm, got, want)
+				}
+			}
+		})
 	}
 }

--- a/internal/bdrom/streamfile_length_test.go
+++ b/internal/bdrom/streamfile_length_test.go
@@ -5,32 +5,32 @@ import "testing"
 func TestStreamFileLengthUsesDTSOnly(t *testing.T) {
 	s := &StreamFile{}
 	state := &streamState{}
-	states := map[uint16]*streamState{0x1011: state}
+	activeStates := []activeStreamEntry{{pid: 0x1011, state: state, isVideo: true}}
 
 	first := uint64(0)
 	last := uint64(0)
 
 	// First DTS-bearing timestamp: should not set length (BDInfo skips the first timestamp).
-	s.handleTimestamp(nil, nil, nil, states, 0x1011, state, 1000, 1000, true, &first, &last)
+	s.handleTimestamp(nil, nil, nil, activeStates, 0x1011, state, 1000, 1000, true, &first, &last)
 	if s.Length != 0 {
 		t.Fatalf("expected length 0 after first timestamp, got %v", s.Length)
 	}
 
 	// Second DTS-bearing timestamp: duration baseline begins here.
-	s.handleTimestamp(nil, nil, nil, states, 0x1011, state, 2000, 2000, true, &first, &last)
+	s.handleTimestamp(nil, nil, nil, activeStates, 0x1011, state, 2000, 2000, true, &first, &last)
 	if s.Length != 0 {
 		t.Fatalf("expected length 0 after second timestamp (first==last), got %v", s.Length)
 	}
 
 	// PTS-only timestamp advances presentation time but must not extend TSStreamFile.Length.
 	// dtsForLength remains the last seen DTS.
-	s.handleTimestamp(nil, nil, nil, states, 0x1011, state, 3000, 2000, true, &first, &last)
+	s.handleTimestamp(nil, nil, nil, activeStates, 0x1011, state, 3000, 2000, true, &first, &last)
 	if s.Length != 0 {
 		t.Fatalf("expected length 0 after PTS-only timestamp, got %v", s.Length)
 	}
 
 	// Next DTS-bearing timestamp extends the file duration.
-	s.handleTimestamp(nil, nil, nil, states, 0x1011, state, 5000, 5000, true, &first, &last)
+	s.handleTimestamp(nil, nil, nil, activeStates, 0x1011, state, 5000, 5000, true, &first, &last)
 	want := float64(5000-2000) / 90000.0
 	if s.Length != want {
 		t.Fatalf("expected length %v, got %v", want, s.Length)


### PR DESCRIPTION
Precompute a `[]activeStreamEntry{pid, state, isVideo}` once at scan setup and range it in `updateStreamBitrates` instead of ranging the `states` map and re-hashing `s.Streams[pid]` on every video-DTS flush (~200-400K flushes per feature). Addresses #19 (candidate 2).

Byte-identical: per-PID accumulators are disjoint so iteration order is irrelevant (the old map range was already randomized), and the cached `isVideo` flag reproduces the `s.Streams[pid]` video-skip exactly. Verified by a new differential test (old map loop vs new slice loop, every branch × 5 orderings) and a byte-identical rendered-report diff on real AVC and HEVC/DV UHD discs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream scanning performance during playback/analysis, reducing unnecessary work on each flush.
  * Preserved bitrate and duration calculations across different stream ordering and edge cases, including streams with missing metadata.
  * Fixed timestamp handling so duration continues to rely on the correct time markers, keeping reported length accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->