### PR TITLE
perf(scan): scan HEVC tag while buffering to cut per-frame memmove

### DIFF
--- a/internal/bdrom/streamfile.go
+++ b/internal/bdrom/streamfile.go
@@ -372,6 +372,9 @@ type streamState struct {
 	hevcTagBuf          []byte
 	hevcTagState        codec.HEVCTagState
 	hevcTagInitialized  bool
+	hevcScanner         codec.HEVCTagScanner
+	hevcTagResolved     bool
+	hevcResolvedTag     string
 	pesHeaderRemaining  int
 	pesHeaderExtraKnown bool
 	pesPacketRemaining  int
@@ -742,10 +745,30 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 					// Avoid stale tags: if we don't have any bytes for the prior transfer, treat it as no tag.
 					if state.hevcTagBuf == nil {
 						state.streamTag = ""
+					} else if state.hevcTagInitialized {
+						// Initialized mode: the tag was resolved incrementally while buffering
+						// (scan-while-buffer, see the append branch below). If a slice resolved,
+						// use the latched tag; otherwise finalize the scanner over the full buffer
+						// to finish SPS/PPS state and pick up any trailing slice. Byte-identical to
+						// HEVCFrameTagFromTransfer(&state.hevcTagState, buf, true) by construction
+						// (FuzzHEVCTagScannerEquivalence).
+						if state.hevcTagResolved {
+							state.streamTag = state.hevcResolvedTag
+						} else {
+							state.streamTag, _ = state.hevcScanner.Scan(&state.hevcTagState, state.hevcTagBuf, true)
+						}
+						state.hevcTagBuf = state.hevcTagBuf[:0]
 					} else {
-						state.streamTag = codec.HEVCFrameTagFromTransfer(&state.hevcTagState, state.hevcTagBuf, state.hevcTagInitialized)
+						// Uninitialized mode keeps the batch scan over the (up to 5MB) buffer: the
+						// "last slice wins" semantics need the whole transfer, so there is no early
+						// stop to exploit.
+						state.streamTag = codec.HEVCFrameTagFromTransfer(&state.hevcTagState, state.hevcTagBuf, false)
 						state.hevcTagBuf = state.hevcTagBuf[:0]
 					}
+					// Reset the per-transfer streaming scanner for the next transfer.
+					state.hevcScanner = codec.HEVCTagScanner{}
+					state.hevcTagResolved = false
+					state.hevcResolvedTag = ""
 					// Match BDInfo: HEVC tag scan switches to "initialized" behavior once an SPS has been seen.
 					if !state.hevcTagInitialized && state.hevcTagState.HasSPS() {
 						state.hevcTagInitialized = true
@@ -819,21 +842,43 @@ func (s *StreamFile) ScanWithProgress(playlists []*PlaylistFile, full bool, onBy
 		if state.collectDiagnostics && isVideo && len(payload) > 0 {
 			if vs, ok := st.(*stream.VideoStream); ok {
 				if vs.StreamType == stream.StreamTypeHEVCVideo {
-					if state.hevcTagBuf == nil {
+					if state.hevcTagInitialized {
+						// Initialized mode: scan while buffering and stop once the first slice tag
+						// resolves, so we copy only the payload up to that slice instead of the
+						// whole 64KB cap (the dominant per-frame memmove on HEVC UHD scans). Once
+						// resolved, skip further buffering/scanning for this transfer. The result
+						// is byte-identical to the batch scan (FuzzHEVCTagScannerEquivalence).
+						if !state.hevcTagResolved {
+							if state.hevcTagBuf == nil {
+								state.hevcTagBuf = make([]byte, 0, 64<<10)
+							}
+							if len(state.hevcTagBuf) < cap(state.hevcTagBuf) {
+								need := cap(state.hevcTagBuf) - len(state.hevcTagBuf)
+								if len(payload) > need {
+									state.hevcTagBuf = append(state.hevcTagBuf, payload[:need]...)
+								} else {
+									state.hevcTagBuf = append(state.hevcTagBuf, payload...)
+								}
+							}
+							if tag, ok := state.hevcScanner.Scan(&state.hevcTagState, state.hevcTagBuf, false); ok {
+								state.hevcTagResolved = true
+								state.hevcResolvedTag = tag
+							}
+						}
+					} else {
 						// Match BDInfo: before initialization, TSStreamBuffer captures up to 5MB
-						// and HEVC tag selection can depend on later slices overwriting earlier ones.
-						if state.hevcTagInitialized {
-							state.hevcTagBuf = make([]byte, 0, 64<<10)
-						} else {
+						// and HEVC tag selection can depend on later slices overwriting earlier ones,
+						// so the whole transfer is buffered and resolved by the batch scan.
+						if state.hevcTagBuf == nil {
 							state.hevcTagBuf = make([]byte, 0, 5*1024*1024)
 						}
-					}
-					if len(state.hevcTagBuf) < cap(state.hevcTagBuf) {
-						need := cap(state.hevcTagBuf) - len(state.hevcTagBuf)
-						if len(payload) > need {
-							state.hevcTagBuf = append(state.hevcTagBuf, payload[:need]...)
-						} else {
-							state.hevcTagBuf = append(state.hevcTagBuf, payload...)
+						if len(state.hevcTagBuf) < cap(state.hevcTagBuf) {
+							need := cap(state.hevcTagBuf) - len(state.hevcTagBuf)
+							if len(payload) > need {
+								state.hevcTagBuf = append(state.hevcTagBuf, payload[:need]...)
+							} else {
+								state.hevcTagBuf = append(state.hevcTagBuf, payload...)
+							}
 						}
 					}
 				} else if state.streamTag == "" {

--- a/internal/bdrom/streamfile_hevc_tag_scan_test.go
+++ b/internal/bdrom/streamfile_hevc_tag_scan_test.go
@@ -1,0 +1,134 @@
+package bdrom
+
+import (
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/stream"
+)
+
+// This is an end-to-end integration test for the HEVC per-transfer tag path: it
+// scans a synthetic Annex-B HEVC transport stream and checks the StreamDiagnostics
+// tags. The codec scanner itself is proven byte-identical to the batch oracle by
+// FuzzHEVCTagScannerEquivalence; this test exercises the streamfile.go wiring around
+// it — the uninitialized->initialized transition, scan-while-buffering with the
+// per-transfer reset, and HEVCTagState persistence across transfers.
+
+// Minimal HEVC NAL bodies that the tag parser accepts (see internal/codec).
+var (
+	hevcStartCode = []byte{0x00, 0x00, 0x01}
+	// SPS (nal type 33): vps_id/maxSubLayers=0/nesting=0, zero profile_tier_level
+	// (12 bytes), then sps_id ue(0). Parses to spsValid[0]=true.
+	hevcSPS = append([]byte{0x42, 0x01, 0x00},
+		append(make([]byte, 12), 0x80)...)
+	// PPS (nal type 34): pps_id ue(0), sps_id ue(0), dependent=0, output=0, extra=0.
+	hevcPPS = []byte{0x44, 0x01, 0xC0}
+	// Slice (nal type 1) headers: first_slice=1, pps_id=0, slice_type {0:P,1:B,2:I}.
+	hevcSliceI = []byte{0x02, 0x01, 0xD8}
+	hevcSliceP = []byte{0x02, 0x01, 0xE0}
+	hevcSliceB = []byte{0x02, 0x01, 0xD0}
+)
+
+func hevcNAL(nal []byte) []byte { return append(append([]byte{}, hevcStartCode...), nal...) }
+
+// hevcSEI builds a non-VCL SEI NAL (type 39) with a body of n start-code-free bytes,
+// so a transfer can be made large enough to span multiple TS packets (forcing the
+// streaming scanner to feed incrementally before the trailing slice resolves).
+func hevcSEI(n int) []byte {
+	nal := []byte{39 << 1, 0x01}
+	body := make([]byte, n)
+	for i := range body {
+		body[i] = byte(i*7+1) | 0x04 // avoid 00 00 0x sequences
+	}
+	return append(nal, body...)
+}
+
+// hevcFrameES builds the elementary-stream (Annex-B) payload for one access unit.
+func hevcFrameES(nals ...[]byte) []byte {
+	var es []byte
+	for _, n := range nals {
+		es = append(es, hevcNAL(n)...)
+	}
+	return es
+}
+
+// hevcPESPackets wraps a frame's ES in a PES header (PTS+DTS) and splits it across
+// 188-byte TS packets on the given PID, so multi-packet transfers are exercised.
+func hevcPESPackets(pid uint16, pts, dts uint64, es []byte) []byte {
+	ptsB := encodePTS(0x30, pts)
+	dtsB := encodePTS(0x10, dts)
+	pes := []byte{0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0xC0, 0x0A}
+	pes = append(pes, ptsB[:]...)
+	pes = append(pes, dtsB[:]...)
+	pes = append(pes, es...)
+
+	var out []byte
+	first := true
+	for len(pes) > 0 {
+		take := min(len(pes), 184)
+		var payload [184]byte
+		copy(payload[:], pes[:take])
+		pkt := tsPacket188(pid, first, payload[:])
+		out = append(out, pkt[:]...)
+		pes = pes[take:]
+		first = false
+	}
+	return out
+}
+
+func TestStreamFileHEVCTagScan_Integration(t *testing.T) {
+	const pid = 0x1011
+
+	// Frame 1 carries SPS+PPS (so the scan transitions to initialized after it) plus
+	// an I slice. Frames 2..5 carry only a slice each — proving HEVCTagState (the PPS)
+	// persists across transfers and the streaming scanner resolves single-slice frames.
+	frames := []struct {
+		slice []byte
+		tag   string
+		extra [][]byte // NALs before the slice
+	}{
+		{slice: hevcSliceI, tag: "I", extra: [][]byte{hevcSPS, hevcPPS}},
+		{slice: hevcSliceP, tag: "P"},
+		// A ~600-byte SEI before the slice makes this transfer span several TS packets,
+		// so the streaming scanner feeds incrementally and resolves the trailing slice
+		// only once enough packets have arrived.
+		{slice: hevcSliceB, tag: "B", extra: [][]byte{hevcSEI(600)}},
+		{slice: hevcSliceI, tag: "I"},
+		{slice: hevcSliceP, tag: "P"},
+	}
+
+	var data []byte
+	for i, f := range frames {
+		nals := append(append([][]byte{}, f.extra...), f.slice)
+		dts := uint64(90000 * (i + 1))
+		data = append(data, hevcPESPackets(pid, dts, dts, hevcFrameES(nals...))...)
+	}
+
+	fi := &memFileInfo{name: "HEVC.M2TS", data: data}
+	s := NewStreamFile(fi)
+	s.Streams[pid] = &stream.VideoStream{Stream: stream.Stream{PID: pid, StreamType: stream.StreamTypeHEVCVideo}}
+
+	// A non-nil playlist is required for updateStreamBitrates (and thus the
+	// StreamDiagnostics rows) to run; no matching clips are needed for the tag path.
+	playlists := []*PlaylistFile{{}}
+	if err := s.ScanWithProgress(playlists, false, nil); err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	var gotTags []string
+	for _, d := range s.StreamDiagnostics[pid] {
+		gotTags = append(gotTags, d.Tag)
+	}
+
+	// The tag recorded at frame K's DTS flush is the tag of transfer K-1 (resolved at
+	// frame K's PES start). With 5 frames the flushes at frames 2..5 record frames 1..4:
+	// I (frame1, uninitialized batch), then P, B, I (frames 2..4, streaming scanner).
+	want := []string{"I", "P", "B", "I"}
+	if len(gotTags) != len(want) {
+		t.Fatalf("got %d diagnostics tags %q, want %d %q", len(gotTags), gotTags, len(want), want)
+	}
+	for i := range want {
+		if gotTags[i] != want[i] {
+			t.Fatalf("diagnostics tag[%d]=%q, want %q (all: %q)", i, gotTags[i], want[i], gotTags)
+		}
+	}
+}

--- a/internal/codec/hevc_tag_scanner.go
+++ b/internal/codec/hevc_tag_scanner.go
@@ -35,11 +35,13 @@ func applyHEVCNAL(state *HEVCTagState, nal []byte) (tag string, isDefault bool, 
 // peekHEVCSliceTag parses a still-growing trailing NAL as a slice WITHOUT mutating
 // state, so the scanner can resolve the common single-slice access unit (whose slice
 // is the last NAL, with no trailing start code) before the whole 64KB buffer is
-// copied. A non-null result is final: it depends only on the slice header at the
-// start of the NAL, so trailing bytes cannot change it (if the header is incomplete,
-// parseHEVCSliceTag returns "" and the caller waits for more bytes). SPS/PPS
-// (nal types 33/34) mutate state and so are deliberately never peeked — they are
-// only applied once fully delimited or at finalize.
+// copied. It depends only on the slice header at the start of the NAL, so a non-null
+// result is final PROVIDED the caller only feeds bytes that are committed to the NAL
+// — Scan enforces this by trimming the final 3 bytes of the buffer, which could still
+// turn out to be (the leading bytes of) the next start code. If the header is
+// incomplete, parseHEVCSliceTag returns "" and the caller waits for more bytes.
+// SPS/PPS (nal types 33/34) mutate state and so are deliberately never peeked — they
+// are only applied once fully delimited or at finalize.
 func peekHEVCSliceTag(state *HEVCTagState, nal []byte) string {
 	if len(nal) < 3 {
 		return ""
@@ -159,10 +161,19 @@ func (sc *HEVCTagScanner) Scan(state *HEVCTagState, buf []byte, finalize bool) (
 				// Early resolve: the trailing (not-yet-delimited) NAL is most often the
 				// single slice of the access unit. If it is a slice whose header is already
 				// buffered, resolve read-only and stop copying the rest of the transfer.
-				if t := peekHEVCSliceTag(state, buf[nalStart:]); t != "" {
-					sc.resolved = true
-					sc.tag = t
-					return sc.tag, true
+				//
+				// Peek only the bytes provably committed to this NAL: a start code
+				// completed by a byte that has not arrived yet can begin no earlier than
+				// len(buf)-3 (nextStartCode never recognizes a start code in the final 3
+				// bytes, and the 4-byte form backs up one zero). Peeking the final 3 bytes
+				// could read a leading 0x00 of the next start code and resolve a slice_type
+				// the batch path — which delimits the NAL at that start code — never sees.
+				if peekEnd := len(buf) - 3; peekEnd > nalStart {
+					if t := peekHEVCSliceTag(state, buf[nalStart:peekEnd]); t != "" {
+						sc.resolved = true
+						sc.tag = t
+						return sc.tag, true
+					}
 				}
 				sc.search = resumeOffset(len(buf), nalStart)
 				return "", false

--- a/internal/codec/hevc_tag_scanner.go
+++ b/internal/codec/hevc_tag_scanner.go
@@ -1,0 +1,187 @@
+package codec
+
+import "bytes"
+
+// applyHEVCNAL applies a single Annex-B NAL (without its start code) to the tag
+// state, mirroring the per-NAL body of HEVCFrameTagFromTransfer exactly:
+//   - validates the 2-byte NAL header (forbidden_zero_bit==0, temporal_id_plus1!=0)
+//   - SPS (type 33) / PPS (type 34) update state
+//   - any other type is run through parseHEVCSliceTag (which returns "" for
+//     non-slice types)
+//
+// It returns the slice tag, whether the NAL hit the default (non-SPS/PPS) branch,
+// and whether the NAL header was valid at all. Callers replicate the batch
+// function's initialized/uninitialized tag selection from these. Equivalence to the
+// batch function's inline NAL handling is enforced by FuzzHEVCTagScannerEquivalence.
+func applyHEVCNAL(state *HEVCTagState, nal []byte) (tag string, isDefault bool, valid bool) {
+	if len(nal) < 3 {
+		return "", false, false
+	}
+	if (nal[0]&0x80) != 0 || (nal[1]&0x07) == 0 {
+		return "", false, false
+	}
+	switch nalUnitType := (nal[0] >> 1) & 0x3F; nalUnitType {
+	case 33: // SPS
+		parseHEVCSPS(state, nal)
+		return "", false, true
+	case 34: // PPS
+		parseHEVCPPS(state, nal)
+		return "", false, true
+	default:
+		return parseHEVCSliceTag(state, nal, nalUnitType), true, true
+	}
+}
+
+// peekHEVCSliceTag parses a still-growing trailing NAL as a slice WITHOUT mutating
+// state, so the scanner can resolve the common single-slice access unit (whose slice
+// is the last NAL, with no trailing start code) before the whole 64KB buffer is
+// copied. A non-null result is final: it depends only on the slice header at the
+// start of the NAL, so trailing bytes cannot change it (if the header is incomplete,
+// parseHEVCSliceTag returns "" and the caller waits for more bytes). SPS/PPS
+// (nal types 33/34) mutate state and so are deliberately never peeked — they are
+// only applied once fully delimited or at finalize.
+func peekHEVCSliceTag(state *HEVCTagState, nal []byte) string {
+	if len(nal) < 3 {
+		return ""
+	}
+	if (nal[0]&0x80) != 0 || (nal[1]&0x07) == 0 {
+		return ""
+	}
+	nalUnitType := (nal[0] >> 1) & 0x3F
+	if nalUnitType == 33 || nalUnitType == 34 {
+		return ""
+	}
+	return parseHEVCSliceTag(state, nal, nalUnitType)
+}
+
+// nextStartCodeResume is a stateful variant of nextStartCode that searches for the
+// next Annex-B start code from searchStart while classifying the 3-byte vs 4-byte
+// form relative to canonStart. It returns the same (index, length) as
+// nextStartCode(data, canonStart) PROVIDED the caller guarantees no start code
+// exists in [canonStart, searchStart) — the incremental scanner upholds this by only
+// advancing searchStart across regions a prior search already proved empty. This
+// lets the scanner avoid re-scanning bytes it has already passed (O(n) over a
+// growing buffer instead of O(n^2)). nextStartCodeResume(data, s, s) is identical to
+// nextStartCode(data, s); FuzzNextStartCodeResumeEquivalence pins that.
+func nextStartCodeResume(data []byte, searchStart, canonStart int) (int, int) {
+	if searchStart < canonStart {
+		searchStart = canonStart
+	}
+	if searchStart < 0 {
+		searchStart = 0
+	}
+	rel := bytes.Index(data[searchStart:], startCode3)
+	if rel < 0 {
+		return -1, 0
+	}
+	p := searchStart + rel
+	if p-1 >= canonStart && data[p-1] == 0x00 {
+		return p - 1, 4
+	}
+	if p+3 < len(data) {
+		return p, 3
+	}
+	return -1, 0
+}
+
+// resumeOffset returns where to resume a start-code search after a search over a
+// buffer of length n (relative to canonStart) found nothing. It backs up 3 bytes
+// from the buffer end so a start code that straddles the previous buffer boundary
+// (or one that was excluded only by the 3-byte end bound) is re-examined once more
+// bytes arrive, while never going below canonStart.
+func resumeOffset(n, canonStart int) int {
+	if r := n - 3; r > canonStart {
+		return r
+	}
+	return canonStart
+}
+
+// HEVCTagScanner incrementally derives the per-transfer HEVC frame tag from a
+// growing Annex-B buffer, mirroring HEVCFrameTagFromTransfer(state, buf, true)
+// (initialized mode) without re-scanning bytes it has already passed. Feeding the
+// buffer as it grows and stopping at the first resolved slice lets the caller stop
+// copying the rest of the transfer payload (the over-buffering this avoids was the
+// dominant per-frame memmove in HEVC UHD scans). Equivalence to the batch function
+// for arbitrary inputs and arbitrary chunk splits is enforced by
+// FuzzHEVCTagScannerEquivalence.
+type HEVCTagScanner struct {
+	started  bool   // first start code located
+	resolved bool   // a non-null slice tag was found (initialized-mode early stop)
+	done     bool   // the whole buffer has been walked (finalize processed the tail)
+	tag      string // resolved tag
+	pos      int    // current start code position
+	scLen    int    // current start code length (3 or 4)
+	search   int    // resume offset for the next start-code search
+}
+
+// Scan walks any NALs newly delimited in buf (the accumulated transfer so far),
+// applying SPS/PPS to state and stopping at the first non-null slice tag. When
+// finalize is true, buf is the complete transfer, so the trailing NAL (delimited by
+// the buffer end) is processed too. It returns the resolved tag and whether a
+// non-null slice tag was found. Once resolved or finalized, further calls are
+// no-ops. The end result (tag and state mutations) equals
+// HEVCFrameTagFromTransfer(state, finalBuf, true).
+func (sc *HEVCTagScanner) Scan(state *HEVCTagState, buf []byte, finalize bool) (string, bool) {
+	if sc.resolved || sc.done {
+		return sc.tag, sc.resolved
+	}
+	if state == nil {
+		return "", false
+	}
+	// HEVCFrameTagFromTransfer requires at least 6 bytes; a transfer that ends
+	// shorter yields "" with no NAL processing. A buffer below 6 bytes can never
+	// contain a delimited NAL, so nothing was processed incrementally either.
+	if finalize && len(buf) < 6 {
+		sc.done = true
+		return "", false
+	}
+
+	if !sc.started {
+		p, l := nextStartCodeResume(buf, sc.search, 0)
+		if p == -1 {
+			if finalize {
+				sc.done = true
+				return "", false
+			}
+			sc.search = resumeOffset(len(buf), 0)
+			return "", false
+		}
+		sc.started = true
+		sc.pos, sc.scLen = p, l
+		sc.search = sc.pos + sc.scLen
+	}
+
+	for {
+		nalStart := sc.pos + sc.scLen
+		nextPos, nextLen := nextStartCodeResume(buf, sc.search, nalStart)
+		if nextPos == -1 {
+			if !finalize {
+				// Early resolve: the trailing (not-yet-delimited) NAL is most often the
+				// single slice of the access unit. If it is a slice whose header is already
+				// buffered, resolve read-only and stop copying the rest of the transfer.
+				if t := peekHEVCSliceTag(state, buf[nalStart:]); t != "" {
+					sc.resolved = true
+					sc.tag = t
+					return sc.tag, true
+				}
+				sc.search = resumeOffset(len(buf), nalStart)
+				return "", false
+			}
+			// Trailing NAL runs to the buffer end (batch: nalEnd = len(data)).
+			if t, isDefault, valid := applyHEVCNAL(state, buf[nalStart:]); valid && isDefault && t != "" {
+				sc.resolved = true
+				sc.tag = t
+			}
+			sc.done = true
+			return sc.tag, sc.resolved
+		}
+		// Complete NAL delimited by [nalStart, nextPos).
+		if t, isDefault, valid := applyHEVCNAL(state, buf[nalStart:nextPos]); valid && isDefault && t != "" {
+			sc.resolved = true
+			sc.tag = t
+			return sc.tag, true
+		}
+		sc.pos, sc.scLen = nextPos, nextLen
+		sc.search = sc.pos + sc.scLen
+	}
+}

--- a/internal/codec/hevc_tag_scanner_test.go
+++ b/internal/codec/hevc_tag_scanner_test.go
@@ -68,6 +68,51 @@ func TestHEVCTagScanner_MatchesBatch_AcrossSplits(t *testing.T) {
 	}
 }
 
+// scNAL prepends a 3-byte start code to a NAL body.
+func scNAL(nal ...byte) []byte { return append([]byte{0x00, 0x00, 0x01}, nal...) }
+
+// hevcSPSBytes / hevcPPSBytes / hevcSlice are minimal NAL bodies the real parsers
+// accept, used to build SPS->PPS->slice transfers that resolve to a non-empty tag.
+var (
+	// SPS (type 33): zero profile_tier_level (12 bytes) + sps_id ue(0) => spsValid[0]=true.
+	hevcSPSBytes = append([]byte{0x42, 0x01, 0x00}, append(make([]byte, 12), 0x80)...)
+	// PPS (type 34) body 0xE6 => pps_id 0, sps_id 0, dependent=1, output=0, extra=3.
+	hevcPPSBytes = []byte{0x44, 0x01, 0xE6}
+)
+
+// TestHEVCTagScanner_BoundaryStraddle is a regression guard for the peek-past-NAL bug:
+// a slice NAL whose slice_type Exp-Golomb code is truncated at the true NAL boundary
+// must yield the SAME tag as the batch oracle, even when the next start code's leading
+// 0x00 bytes follow it in the buffer. Before the fix, the early-resolve peek read those
+// out-of-NAL bytes and latched "B" while the batch path (which delimits the NAL at the
+// start code) yields "". The scanner must match the batch for every chunk split.
+func TestHEVCTagScanner_BoundaryStraddle(t *testing.T) {
+	// SPS, then PPS(extra=3) so slice_type sits just past the 1-byte slice body, then an
+	// IRAP slice (type 19, body 0xA1) whose slice_type ue needs a bit beyond the NAL,
+	// then a trailing non-first slice. Batch delimits the IRAP slice to [26 01 A1] -> "".
+	transfer := scNAL(hevcSPSBytes...)
+	transfer = append(transfer, scNAL(hevcPPSBytes...)...)
+	transfer = append(transfer, scNAL(0x26, 0x01, 0xA1)...)
+	transfer = append(transfer, scNAL(0x02, 0x01, 0x40)...)
+
+	var batchState HEVCTagState
+	want := HEVCFrameTagFromTransfer(&batchState, transfer, true)
+	if want != "" {
+		t.Fatalf("oracle sanity: a slice truncated at the NAL boundary must be null, got %q", want)
+	}
+
+	for chunk := 1; chunk <= len(transfer)+1; chunk++ {
+		var st HEVCTagState
+		got := feedScanner(&st, transfer, func(*uint32) int { return chunk })
+		if got != want {
+			t.Fatalf("chunk=%d: scanner tag %q != batch %q (peek read past the NAL boundary)", chunk, got, want)
+		}
+		if st != batchState {
+			t.Fatalf("chunk=%d: scanner state diverged from batch", chunk)
+		}
+	}
+}
+
 // FuzzHEVCTagScannerEquivalence is the correctness guarantee that keeps rendered
 // reports byte-identical: for arbitrary Annex-B input fed in arbitrary chunk splits,
 // the streaming scanner must produce the same tag AND the same final HEVCTagState as
@@ -87,6 +132,14 @@ func FuzzHEVCTagScannerEquivalence(f *testing.F) {
 		{0x00, 0x00, 0x01, 0x02, 0x01, 0xD8, 0x00, 0x00, 0x01, 0x02, 0x01, 0x40},
 		// 4-byte start codes interleaved with 3-byte.
 		{0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0xAA, 0x00, 0x00, 0x01, 0x02, 0x01, 0xD8},
+		// SPS -> PPS -> I slice with body so the resolved-tag ("I") path is exercised
+		// from a fresh state (parseHEVCPPS only validates a PPS whose SPS is valid, so
+		// the chain must include a real SPS first).
+		append(append(scNAL(hevcSPSBytes...), scNAL(hevcPPSBytes...)...),
+			scNAL(0x26, 0x01, 0xD8, 0x00)...),
+		// The boundary-straddle regression case (batch -> "", scanner must match).
+		append(append(scNAL(hevcSPSBytes...), scNAL(hevcPPSBytes...)...),
+			append(scNAL(0x26, 0x01, 0xA1), scNAL(0x02, 0x01, 0x40)...)...),
 	}
 	for _, s := range seeds {
 		for _, seed := range []uint32{1, 2, 3, 7, 0x1234} {

--- a/internal/codec/hevc_tag_scanner_test.go
+++ b/internal/codec/hevc_tag_scanner_test.go
@@ -1,0 +1,147 @@
+package codec
+
+import (
+	"testing"
+)
+
+// feedScanner drives a HEVCTagScanner over data split into chunks of the given
+// sizes (simulating per-TS-packet arrival into the accumulated transfer buffer),
+// finalizing on the last chunk. It returns the resolved tag. The scanner always
+// sees a growing prefix of the same contiguous buffer, exactly as in streamfile.go.
+func feedScanner(state *HEVCTagState, data []byte, step func(seed *uint32) int) string {
+	var sc HEVCTagScanner
+	tag := ""
+	seed := uint32(0x9e3779b9)
+	i := 0
+	for i < len(data) {
+		n := max(step(&seed), 1)
+		j := min(i+n, len(data))
+		tag, _ = sc.Scan(state, data[:j], j == len(data))
+		i = j
+	}
+	if len(data) == 0 {
+		tag, _ = sc.Scan(state, data, true)
+	}
+	return tag
+}
+
+// TestHEVCTagScanner_MatchesBatch_AcrossSplits checks the streaming scanner against
+// the batch oracle on the same two-slice transfer used by the batch unit test, for
+// every fixed chunk size from 1 byte (every start code straddles a boundary) up to
+// the whole buffer at once.
+func TestHEVCTagScanner_MatchesBatch_AcrossSplits(t *testing.T) {
+	start := []byte{0x00, 0x00, 0x01}
+	nalHeader := func(nalUnitType byte) []byte { return []byte{nalUnitType << 1, 0x01} }
+	sliceFirstI := []byte{0xD8}   // first_slice=1, pps_id=0, slice_type=2 (I)
+	sliceNotFirst := []byte{0x40} // first_slice=0
+
+	transfer := make([]byte, 0, 64)
+	transfer = append(transfer, start...)
+	transfer = append(transfer, nalHeader(1)...)
+	transfer = append(transfer, sliceFirstI...)
+	transfer = append(transfer, start...)
+	transfer = append(transfer, nalHeader(1)...)
+	transfer = append(transfer, sliceNotFirst...)
+
+	seedState := func() HEVCTagState {
+		var st HEVCTagState
+		st.ppsValid[0] = true
+		st.pps[0] = hevcPPS{}
+		return st
+	}
+
+	batchState := seedState()
+	want := HEVCFrameTagFromTransfer(&batchState, transfer, true)
+	if want != "I" {
+		t.Fatalf("oracle sanity: got %q want I", want)
+	}
+
+	for chunk := 1; chunk <= len(transfer)+1; chunk++ {
+		st := seedState()
+		got := feedScanner(&st, transfer, func(*uint32) int { return chunk })
+		if got != want {
+			t.Fatalf("chunk=%d: scanner tag %q != batch %q", chunk, got, want)
+		}
+		if st != batchState {
+			t.Fatalf("chunk=%d: scanner state diverged from batch", chunk)
+		}
+	}
+}
+
+// FuzzHEVCTagScannerEquivalence is the correctness guarantee that keeps rendered
+// reports byte-identical: for arbitrary Annex-B input fed in arbitrary chunk splits,
+// the streaming scanner must produce the same tag AND the same final HEVCTagState as
+// the batch HEVCFrameTagFromTransfer(state, data, true) it replaces.
+func FuzzHEVCTagScannerEquivalence(f *testing.F) {
+	seeds := [][]byte{
+		nil,
+		{},
+		{0x00, 0x00, 0x01},
+		{0x00, 0x00, 0x01, 0x26, 0x01, 0x9a, 0x00},
+		{0x00, 0x00, 0x01, 0x42, 0x01, 0x01, 0x01}, // SPS-ish (type 33)
+		{0x00, 0x00, 0x01, 0x44, 0x01, 0x01, 0x01}, // PPS-ish (type 34)
+		// AUD + sizeable SEI body + first VCL slice, like a UHD/DV access unit.
+		buildFramePrefix(256),
+		buildFramePrefix(2048),
+		// Two slices: first 'I', then non-first (null) — exercises early stop.
+		{0x00, 0x00, 0x01, 0x02, 0x01, 0xD8, 0x00, 0x00, 0x01, 0x02, 0x01, 0x40},
+		// 4-byte start codes interleaved with 3-byte.
+		{0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0xAA, 0x00, 0x00, 0x01, 0x02, 0x01, 0xD8},
+	}
+	for _, s := range seeds {
+		for _, seed := range []uint32{1, 2, 3, 7, 0x1234} {
+			f.Add(s, seed)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte, splitSeed uint32) {
+		if len(data) > 256<<10 {
+			return
+		}
+
+		var batchState HEVCTagState
+		wantTag := HEVCFrameTagFromTransfer(&batchState, data, true)
+
+		var streamState HEVCTagState
+		s := splitSeed | 1 // seed the chunk PRNG; |1 keeps it off the zero fixpoint
+		got := feedScanner(&streamState, data, func(*uint32) int {
+			s = s*1664525 + 1013904223
+			return int((s>>16)%7) + 1 // 1..7 byte chunks
+		})
+
+		if got != wantTag {
+			t.Fatalf("tag mismatch: got %q want %q data=%x split=%d", got, wantTag, data, splitSeed)
+		}
+		if streamState != batchState {
+			t.Fatalf("state mismatch data=%x split=%d", data, splitSeed)
+		}
+	})
+}
+
+// FuzzNextStartCodeResumeEquivalence pins the helper: searching from the canonical
+// start (searchStart == canonStart) must be identical to nextStartCode, which is
+// itself differentially tested against the original linear scan.
+func FuzzNextStartCodeResumeEquivalence(f *testing.F) {
+	seeds := [][]byte{
+		nil,
+		{0x00, 0x00, 0x01},
+		{0x00, 0x00, 0x00, 0x01},
+		{0x00, 0x00, 0x00, 0x00, 0x01},
+		{0xAA, 0x00, 0x00, 0x01, 0xBB},
+		{0x00, 0x00, 0x01, 0x00, 0x00, 0x01},
+		{0x00, 0x00, 0x01, 0x00, 0x00},
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		for start := 0; start <= len(data); start++ {
+			gotP, gotL := nextStartCodeResume(data, start, start)
+			wantP, wantL := nextStartCode(data, start)
+			if gotP != wantP || gotL != wantL {
+				t.Fatalf("resume(s,s) != nextStartCode start=%d data=%x: got (%d,%d) want (%d,%d)",
+					start, data, gotP, gotL, wantP, wantL)
+			}
+		}
+	})
+}

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -33,6 +33,9 @@ TARGETS=(
   "./internal/codec|FuzzScanAVC"
   "./internal/codec|FuzzScanHEVC"
   "./internal/codec|FuzzHEVCFrameTagFromTransfer"
+  "./internal/codec|FuzzHEVCTagScannerEquivalence"
+  "./internal/codec|FuzzNextStartCodeResumeEquivalence"
+  "./internal/codec|FuzzNextStartCodeEquivalence"
   "./internal/bdrom|FuzzStreamClipFileScan"
   "./internal/bdrom|FuzzParsePTSAndValidateTimestamp"
 )


### PR DESCRIPTION
In initialized mode the per-transfer HEVC frame-tag derivation buffered up to 64KB of payload then scanned it, but the scan stops at the first VCL slice — so most of that copy was wasted (the dominant `runtime.memmove` in HEVC UHD profiles). New `codec.HEVCTagScanner` walks NALs incrementally over the growing buffer and stops at the first resolved slice (read-only peek of the common single-slice trailing NAL), ending the copy there instead of at the 64KB cap. Only initialized mode uses it; the uninitialized 5MB last-slice-wins path keeps the batch scan, which is left untouched as the differential oracle. Addresses #19 (candidate 1).

Byte-identical: `FuzzHEVCTagScannerEquivalence` asserts scanner-fed-in-arbitrary-chunks == batch for both the tag and the resulting `HEVCTagState` (50M+ execs), plus a synthetic-m2ts integration test and a byte-identical rendered-report diff on a real HEVC/DV UHD disc. Sibling of #22 (both from #19); independent, mergeable in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HEVC video scanning to resolve frame tags more smoothly while data is still being buffered, helping diagnostics stay accurate across packet splits.
  * Added broader fuzz coverage for HEVC scanning and start-code detection.

* **Bug Fixes**
  * Fixed boundary handling so frame-tag detection no longer reads past the end of a NAL unit.
  * Improved consistency between streaming and batch tag detection results.

* **Tests**
  * Added end-to-end and regression tests covering split packets, incremental resolution, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->