### PR TITLE
feat(api): add DiscoverPlaylists and fix zero-size display for ISO scans

### DIFF
--- a/internal/bdrom/bdrom.go
+++ b/internal/bdrom/bdrom.go
@@ -476,6 +476,7 @@ func (b *BDROM) ScanMetadata() ScanResult {
 func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 	result := ScanResult{FileErrors: make(map[string]error)}
 	var errMu sync.Mutex
+	var progressMu sync.Mutex
 	emit := func(update ScanProgress) {
 		if progress != nil {
 			progress(update)
@@ -488,6 +489,8 @@ func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 	runParallel(clipFiles, scanWorkerLimit(len(clipFiles), 0), func(clip *StreamClipFile) error {
 		return clip.Scan()
 	}, func(_ *StreamClipFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(clipDone.Add(1))
 		emit(ScanProgress{Stage: ScanStageClipInfo, Completed: done, Total: len(clipFiles)})
 	}, func(clip *StreamClipFile, err error) {
@@ -509,6 +512,8 @@ func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
 		return playlist.Scan(b.StreamFiles, b.StreamClipFiles)
 	}, func(_ *PlaylistFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(playlistDone.Add(1))
 		emit(ScanProgress{Stage: ScanStagePlaylist, Completed: done, Total: len(playlists)})
 	}, func(playlist *PlaylistFile, err error) {
@@ -523,6 +528,8 @@ func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 		playlist.Initialize()
 		return nil
 	}, func(_ *PlaylistFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(initDone.Add(1))
 		emit(ScanProgress{Stage: ScanStageInitialize, Completed: done, Total: len(playlists)})
 	}, nil)
@@ -545,6 +552,7 @@ func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 	result := ScanResult{FileErrors: make(map[string]error)}
 	var errMu sync.Mutex
+	var progressMu sync.Mutex
 	emit := func(update ScanProgress) {
 		if progress != nil {
 			progress(update)
@@ -557,6 +565,8 @@ func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 	runParallel(clipFiles, scanWorkerLimit(len(clipFiles), 0), func(clip *StreamClipFile) error {
 		return clip.Scan()
 	}, func(_ *StreamClipFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(clipDone.Add(1))
 		emit(ScanProgress{Stage: ScanStageClipInfo, Completed: done, Total: len(clipFiles)})
 	}, func(clip *StreamClipFile, err error) {
@@ -578,6 +588,8 @@ func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
 		return playlist.Scan(b.StreamFiles, b.StreamClipFiles)
 	}, func(_ *PlaylistFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(playlistDone.Add(1))
 		emit(ScanProgress{Stage: ScanStagePlaylist, Completed: done, Total: len(playlists)})
 	}, func(playlist *PlaylistFile, err error) {
@@ -607,17 +619,16 @@ func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 	const streamEmitBytes = uint64(4 * 1024 * 1024)
 	const streamEmitInterval = 500 * time.Millisecond
 	emitStream := func(force bool) {
+		streamEmitMu.Lock()
+		defer streamEmitMu.Unlock()
 		processed := streamProcessed.Load()
 		done := int(streamDone.Load())
 		if !force {
-			streamEmitMu.Lock()
 			if processed < streamBytes && processed-lastStreamBytes < streamEmitBytes && (lastStreamEmit.IsZero() || time.Since(lastStreamEmit) < streamEmitInterval) {
-				streamEmitMu.Unlock()
 				return
 			}
 			lastStreamBytes = processed
 			lastStreamEmit = time.Now()
-			streamEmitMu.Unlock()
 		}
 		emit(ScanProgress{Stage: ScanStageStream, Completed: done, Total: len(streamFiles), ProcessedBytes: processed, TotalBytes: streamBytes})
 	}
@@ -645,6 +656,8 @@ func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 		playlist.Initialize()
 		return nil
 	}, func(_ *PlaylistFile) {
+		progressMu.Lock()
+		defer progressMu.Unlock()
 		done := int(initDone.Add(1))
 		emit(ScanProgress{Stage: ScanStageInitialize, Completed: done, Total: len(playlists)})
 	}, nil)

--- a/internal/bdrom/bdrom.go
+++ b/internal/bdrom/bdrom.go
@@ -466,6 +466,82 @@ func (b *BDROM) Scan() ScanResult {
 	return b.ScanWithProgress(nil)
 }
 
+// ScanMetadata scans clip info and playlist files but skips the expensive M2TS stream scan.
+// Use for discovery when only playlist metadata (duration, size, validity) is needed.
+func (b *BDROM) ScanMetadata() ScanResult {
+	return b.ScanMetadataWithProgress(nil)
+}
+
+// ScanMetadataWithProgress is like ScanMetadata but emits progress events.
+func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
+	result := ScanResult{FileErrors: make(map[string]error)}
+	var errMu sync.Mutex
+	emit := func(update ScanProgress) {
+		if progress != nil {
+			progress(update)
+		}
+	}
+
+	clipFiles := orderedStreamClipFiles(b.StreamClipFiles)
+	emit(ScanProgress{Stage: ScanStageClipInfo, Total: len(clipFiles)})
+	var clipDone atomic.Int64
+	runParallel(clipFiles, scanWorkerLimit(len(clipFiles), 0), func(clip *StreamClipFile) error {
+		return clip.Scan()
+	}, func(_ *StreamClipFile) {
+		done := int(clipDone.Add(1))
+		emit(ScanProgress{Stage: ScanStageClipInfo, Completed: done, Total: len(clipFiles)})
+	}, func(clip *StreamClipFile, err error) {
+		errMu.Lock()
+		result.FileErrors[clip.Name] = err
+		errMu.Unlock()
+	})
+
+	for _, streamFile := range b.StreamFiles {
+		ssifName := strings.ToUpper(strings.TrimSuffix(streamFile.Name, ".M2TS") + ".SSIF")
+		if ssif, ok := b.InterleavedFiles[ssifName]; ok {
+			streamFile.InterleavedFile = ssif
+		}
+	}
+
+	playlists := orderedPlaylists(b.PlaylistFiles, b.PlaylistOrder)
+	emit(ScanProgress{Stage: ScanStagePlaylist, Total: len(playlists)})
+	var playlistDone atomic.Int64
+	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
+		return playlist.Scan(b.StreamFiles, b.StreamClipFiles)
+	}, func(_ *PlaylistFile) {
+		done := int(playlistDone.Add(1))
+		emit(ScanProgress{Stage: ScanStagePlaylist, Completed: done, Total: len(playlists)})
+	}, func(playlist *PlaylistFile, err error) {
+		errMu.Lock()
+		result.FileErrors[playlist.Name] = err
+		errMu.Unlock()
+	})
+
+	emit(ScanProgress{Stage: ScanStageInitialize, Total: len(playlists)})
+	var initDone atomic.Int64
+	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
+		playlist.Initialize()
+		return nil
+	}, func(_ *PlaylistFile) {
+		done := int(initDone.Add(1))
+		emit(ScanProgress{Stage: ScanStageInitialize, Completed: done, Total: len(playlists)})
+	}, nil)
+
+	for _, playlist := range playlists {
+		if b.Is50Hz {
+			continue
+		}
+		for _, vs := range playlist.VideoStreams {
+			if vs.FrameRate() == stream.FrameRate25 || vs.FrameRate() == stream.FrameRate50 {
+				b.Is50Hz = true
+			}
+		}
+	}
+
+	emit(ScanProgress{Stage: ScanStageComplete, Completed: 1, Total: 1})
+	return result
+}
+
 func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 	result := ScanResult{FileErrors: make(map[string]error)}
 	var errMu sync.Mutex

--- a/internal/bdrom/bdrom.go
+++ b/internal/bdrom/bdrom.go
@@ -535,12 +535,20 @@ func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
 	}, nil)
 
 	for _, playlist := range playlists {
-		if b.Is50Hz {
-			continue
-		}
+		vidCount := len(playlist.VideoStreams)
 		for _, vs := range playlist.VideoStreams {
-			if vs.FrameRate() == stream.FrameRate25 || vs.FrameRate() == stream.FrameRate50 {
+			if !b.Is50Hz && (vs.FrameRate() == stream.FrameRate25 || vs.FrameRate() == stream.FrameRate50) {
 				b.Is50Hz = true
+			}
+			if vidCount > 1 && b.Is3D {
+				if (vs.StreamType == stream.StreamTypeAVCVideo && playlist.MVCBaseViewR) ||
+					(vs.StreamType == stream.StreamTypeMVCVideo && !playlist.MVCBaseViewR) {
+					base := true
+					vs.BaseView = &base
+				} else if vs.StreamType == stream.StreamTypeAVCVideo || vs.StreamType == stream.StreamTypeMVCVideo {
+					base := false
+					vs.BaseView = &base
+				}
 			}
 		}
 	}

--- a/internal/bdrom/playlist.go
+++ b/internal/bdrom/playlist.go
@@ -127,6 +127,26 @@ func (p *PlaylistFile) FileSize() uint64 {
 	return size
 }
 
+// MainAngleFileSize returns the sum of file sizes for angle-0 clips only, deduplicating
+// loop repetitions. Mirrors TotalSize() but uses filesystem sizes instead of packet counts.
+// Use as a metadata-only fallback when TotalSize() is zero and no M2TS scan was performed.
+func (p *PlaylistFile) MainAngleFileSize() uint64 {
+	seen := make(map[clipRefKey]struct{})
+	var size uint64
+	for _, clip := range p.StreamClips {
+		if clip.AngleIndex != 0 {
+			continue
+		}
+		key := newClipRefKey(clip)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		size += clip.FileSize
+	}
+	return size
+}
+
 func (p *PlaylistFile) InterleavedFileSize() uint64 {
 	var size uint64
 	for _, clip := range p.uniqueClipRefs() {

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -115,6 +115,50 @@ type Result struct {
 	ReportPath string
 }
 
+// DiscoverPlaylists opens the disc and returns playlist metadata without scanning stream files.
+// Faster than Run for discovery: scans CLPI and MPLS only, skips the expensive M2TS read.
+// The returned Result has Disc and Playlists populated; Report is always empty.
+func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
+	if options.Path == "" {
+		return Result{}, errors.New("path is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	cfg := toInternalSettings(options.Settings)
+	rom, err := bdrom.New(options.Path, cfg)
+	if err != nil {
+		return Result{}, err
+	}
+	defer rom.Close()
+
+	if err := filterROMToPlaylist(rom, cfg.PlaylistOnly); err != nil {
+		return Result{}, err
+	}
+
+	emit(options.OnProgress, ProgressEvent{
+		Stage:      StageDiscovered,
+		Path:       options.Path,
+		Playlists:  len(rom.PlaylistFiles),
+		ClipInfos:  len(rom.StreamClipFiles),
+		Streams:    len(rom.StreamFiles),
+		OccurredAt: time.Now(),
+	})
+
+	scan := rom.ScanMetadata()
+
+	playlists := orderedPlaylists(rom)
+	return Result{
+		Disc:      buildDiscInfo(rom),
+		Playlists: buildPlaylistInfo(playlists),
+		Scan:      buildScanInfo(scan),
+	}, nil
+}
+
 // Run scans one path and returns structured output plus report content.
 // The API does not write files; callers own output persistence behavior.
 func Run(ctx context.Context, options Options) (Result, error) {

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -149,6 +149,11 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 		OccurredAt: time.Now(),
 	})
 
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	start := time.Now()
 	var scan bdrom.ScanResult
 	if options.OnProgress != nil {
 		scan = rom.ScanMetadataWithProgress(func(update bdrom.ScanProgress) {
@@ -167,6 +172,15 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 	} else {
 		scan = rom.ScanMetadata()
 	}
+
+	emit(options.OnProgress, ProgressEvent{
+		Stage:      StageScanComplete,
+		Path:       options.Path,
+		Completed:  1,
+		Total:      1,
+		Elapsed:    time.Since(start),
+		OccurredAt: time.Now(),
+	})
 
 	if err := ctx.Err(); err != nil {
 		return Result{}, err

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -149,7 +149,24 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 		OccurredAt: time.Now(),
 	})
 
-	scan := rom.ScanMetadata()
+	var scan bdrom.ScanResult
+	if options.OnProgress != nil {
+		scan = rom.ScanMetadataWithProgress(func(update bdrom.ScanProgress) {
+			stage, ok := stageFromScanProgress(update.Stage)
+			if !ok {
+				return
+			}
+			emit(options.OnProgress, ProgressEvent{
+				Stage:      stage,
+				Path:       options.Path,
+				Completed:  update.Completed,
+				Total:      update.Total,
+				OccurredAt: time.Now(),
+			})
+		})
+	} else {
+		scan = rom.ScanMetadata()
+	}
 
 	playlists := orderedPlaylists(rom)
 	return Result{
@@ -335,11 +352,15 @@ func buildPlaylistInfo(playlists []*bdrom.PlaylistFile) []PlaylistInfo {
 		if sizeBytes == 0 {
 			sizeBytes = playlist.FileSize()
 		}
+		var totalBitrateBps uint64
+		if length := playlist.TotalLength(); length > 0 {
+			totalBitrateBps = uint64(float64(sizeBytes) * 8.0 / length)
+		}
 		out = append(out, PlaylistInfo{
 			Name:            playlist.Name,
 			LengthSeconds:   playlist.TotalLength(),
 			SizeBytes:       sizeBytes,
-			TotalBitrateBps: playlist.TotalBitRate(),
+			TotalBitrateBps: totalBitrateBps,
 			HasHiddenTracks: playlist.HasHiddenTracks,
 			IsValid:         playlist.IsValid(),
 		})

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -331,10 +331,14 @@ func buildPlaylistInfo(playlists []*bdrom.PlaylistFile) []PlaylistInfo {
 		if playlist == nil {
 			continue
 		}
+		sizeBytes := playlist.TotalSize()
+		if sizeBytes == 0 {
+			sizeBytes = playlist.FileSize()
+		}
 		out = append(out, PlaylistInfo{
 			Name:            playlist.Name,
 			LengthSeconds:   playlist.TotalLength(),
-			SizeBytes:       playlist.TotalSize(),
+			SizeBytes:       sizeBytes,
 			TotalBitrateBps: playlist.TotalBitRate(),
 			HasHiddenTracks: playlist.HasHiddenTracks,
 			IsValid:         playlist.IsValid(),

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -168,10 +168,14 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 		scan = rom.ScanMetadata()
 	}
 
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
 	playlists := orderedPlaylists(rom)
 	return Result{
 		Disc:      buildDiscInfo(rom),
-		Playlists: buildPlaylistInfo(playlists),
+		Playlists: buildPlaylistInfo(playlists, true),
 		Scan:      buildScanInfo(scan),
 	}, nil
 }
@@ -273,7 +277,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 
 	result := Result{
 		Disc:       buildDiscInfo(rom),
-		Playlists:  buildPlaylistInfo(playlists),
+		Playlists:  buildPlaylistInfo(playlists, false),
 		Scan:       buildScanInfo(scan),
 		Report:     reportText,
 		ReportPath: reportPath,
@@ -342,15 +346,15 @@ func buildDiscInfo(rom *bdrom.BDROM) DiscInfo {
 	}
 }
 
-func buildPlaylistInfo(playlists []*bdrom.PlaylistFile) []PlaylistInfo {
+func buildPlaylistInfo(playlists []*bdrom.PlaylistFile, metadataOnly bool) []PlaylistInfo {
 	out := make([]PlaylistInfo, 0, len(playlists))
 	for _, playlist := range playlists {
 		if playlist == nil {
 			continue
 		}
 		sizeBytes := playlist.TotalSize()
-		if sizeBytes == 0 {
-			sizeBytes = playlist.FileSize()
+		if sizeBytes == 0 && metadataOnly {
+			sizeBytes = playlist.MainAngleFileSize()
 		}
 		var totalBitrateBps uint64
 		if length := playlist.TotalLength(); length > 0 {


### PR DESCRIPTION
  ## What

Adds DiscoverPlaylists, a new API function that reads CLPI and MPLS metadata without scanning M2TS stream files. Faster than Run for use cases that only need playlist discovery before committing to a full scan.

Also fixes a side-effect: TotalSize() returns PacketCount * 192, which is zero when M2TS files are skipped. buildPlaylistInfo now falls back to FileSize() (sums stream file sizes from directory entries, populated during metadata scan) so playlist sizes are correct in both fast and full scan modes.

 ## Why

Callers that only need to present a playlist selection UI were forced to run a full scan. DiscoverPlaylists makes that fast. The size fix makes the returned PlaylistInfo.SizeBytes useful in that context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DiscoverPlaylists(ctx, options)` to discover disc and playlists without a full stream scan.
  * Added metadata-only scanning with progress events covering clip-info, playlist, initialization, and completion.
* **Bug Fixes**
  * Improved playlist size reporting with a metadata-only fallback when full stream sizing isn’t available.
  * Enhanced scan progress emission to be thread-safe, improving reliability of progress updates under parallel processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->