### PR TITLE
fix(udf): handle UDF 2.50 metadata partitions

### DIFF
--- a/internal/fs/udf/file.go
+++ b/internal/fs/udf/file.go
@@ -497,17 +497,7 @@ func (d *Directory) readDirectoryData(ad allocationDescriptor) error {
 		if fid.LengthOfFileIdentifier > 0 {
 			nameData := make([]byte, fid.LengthOfFileIdentifier)
 			fidReader.Read(nameData)
-
-			// Parse the name (simplified - assumes ASCII)
-			// First byte is compression type (usually 8 for 8-bit)
-			if len(nameData) > 1 && nameData[0] == 8 {
-				name := string(nameData[1:])
-				// Remove null terminator if present
-				if idx := strings.IndexByte(name, 0); idx >= 0 {
-					name = name[:idx]
-				}
-				fid.fileName = name
-			}
+			fid.fileName = d.reader.decodeString(nameData)
 		}
 
 		// Store the FID
@@ -876,17 +866,7 @@ func (d *Directory) readEmbeddedDirectoryData(data []byte) error {
 		nameOffset := 38 + int(fid.LengthOfImplementationUse)
 		if fid.LengthOfFileIdentifier > 0 && offset+uint32(nameOffset)+uint32(fid.LengthOfFileIdentifier) <= uint32(len(data)) {
 			nameData := data[offset+uint32(nameOffset) : offset+uint32(nameOffset)+uint32(fid.LengthOfFileIdentifier)]
-
-			// Parse the name (simplified - assumes ASCII)
-			// First byte is compression type (usually 8 for 8-bit)
-			if len(nameData) > 1 && nameData[0] == 8 {
-				name := string(nameData[1:])
-				// Remove null terminator if present
-				if idx := strings.IndexByte(name, 0); idx >= 0 {
-					name = name[:idx]
-				}
-				fid.fileName = name
-			}
+			fid.fileName = d.reader.decodeString(nameData)
 		}
 
 		// Store the FID

--- a/internal/fs/udf/reader.go
+++ b/internal/fs/udf/reader.go
@@ -464,8 +464,8 @@ func decodeLogicalVolumeContentsUse(contentsUse [16]byte) (lbn uint32, pref uint
 		return 0, 0, false
 	}
 
-	lbn = binary.LittleEndian.Uint32(contentsUse[8:12])
-	pref = binary.LittleEndian.Uint16(contentsUse[12:14])
+	lbn = binary.LittleEndian.Uint32(contentsUse[4:8])
+	pref = binary.LittleEndian.Uint16(contentsUse[8:10])
 	if lbn == 0 {
 		return 0, pref, false
 	}

--- a/internal/fs/udf/reader.go
+++ b/internal/fs/udf/reader.go
@@ -432,10 +432,17 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 
 	for _, m := range r.partitionMaps {
 		if m.kind == partitionMapType2 && m.isMetadata {
+			pref := uint16(0)
+			for j, pm2 := range r.partitionMaps {
+				if pm2.kind == partitionMapType1 && pm2.partitionNumber == m.partitionNumber {
+					pref = uint16(j)
+					break
+				}
+			}
 			icb := LongAD{
 				ExtentLocation: LBAddr{
 					LogicalBlockNumber:       m.metadataICBLBN,
-					PartitionReferenceNumber: 0, // metadata file lives in main partition map
+					PartitionReferenceNumber: pref,
 				},
 			}
 			r.metadataFileICB = &icb

--- a/internal/fs/udf/reader.go
+++ b/internal/fs/udf/reader.go
@@ -10,16 +10,17 @@ import (
 
 // Reader provides UDF file system reading capabilities
 type Reader struct {
-	file            *os.File
-	volumeLabel     string
-	blockSize       uint32
-	partitionStart  uint32
-	partitionSize   uint32
-	partitionStarts map[uint16]uint32
-	partitionMaps   []partitionMap
-	rootICB         LongAD
-	fileSetDesc     *FileSetDescriptor
-	fileSetLocation uint32
+	file                      *os.File
+	volumeLabel               string
+	blockSize                 uint32
+	partitionStart            uint32
+	partitionSize             uint32
+	partitionStarts           map[uint16]uint32
+	partitionMaps             []partitionMap
+	rootICB                   LongAD
+	fileSetDesc               *FileSetDescriptor
+	fileSetLocation           uint32
+	fileSetPartitionReference uint16
 
 	metadataFileICB        *LongAD
 	metadataFileAllocDescs []allocationDescriptor
@@ -99,7 +100,10 @@ func (r *Reader) initialize() error {
 	// Now read the file set descriptor after we have partition info
 
 	if r.fileSetLocation > 0 {
-		location := r.partitionStart + r.fileSetLocation
+		location, err := r.fileSetDescriptorBlock()
+		if err != nil {
+			return fmt.Errorf("failed to resolve file set descriptor location: %w", err)
+		}
 
 		if _, err := r.file.Seek(int64(location)*int64(r.blockSize), io.SeekStart); err != nil {
 			return fmt.Errorf("failed to seek to file set descriptor: %w", err)
@@ -275,31 +279,20 @@ func (r *Reader) readVolumeDescriptorSequence(extent ExtentAD) error {
 					return fmt.Errorf("failed to parse partition maps: %w", err)
 				}
 			}
-			// Extract root directory location from logical volume contents use
-			// The first 8 bytes contain the file set descriptor location as ExtentAD
-			_ = binary.LittleEndian.Uint32(lvd.LogicalVolumeContentsUse[0:4]) // fileSetLength
-			fileSetLocation := binary.LittleEndian.Uint32(lvd.LogicalVolumeContentsUse[4:8])
-
-			// Debug: check if LogicalVolumeContentsUse has data
-			hasData := false
-			for _, b := range lvd.LogicalVolumeContentsUse {
-				if b != 0 {
-					hasData = true
-					break
-				}
-			}
-
-			if !hasData || fileSetLocation == 0 {
+			fileSetLocation, fileSetPartitionReference, hasFileSetLocation := decodeLogicalVolumeContentsUse(lvd.LogicalVolumeContentsUse)
+			if !hasFileSetLocation {
 				// LogicalVolumeContentsUse is empty or zero
 				// Try common fallback locations for FileSet descriptor
 				// Most Blu-ray discs put it at sector 32 of the partition
 				fileSetLocation = 32
+				fileSetPartitionReference = 0
 			}
 
 			// We need to defer reading the file set descriptor until after we've processed
 			// all volume descriptors (especially the partition descriptor)
 			// For now, just store the location
 			r.fileSetLocation = fileSetLocation
+			r.fileSetPartitionReference = fileSetPartitionReference
 
 		case TagTerminating:
 			// End of sequence
@@ -419,24 +412,13 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 
 		case partitionMapType2:
 			m := partitionMap{kind: partitionMapType2}
-			if mlen >= 4+32 {
+			if mlen >= 40+4 {
 				ident := strings.TrimRight(string(pm[off+5:off+5+23]), "\x00")
 				ident = strings.TrimPrefix(ident, "*")
 				if ident == udfMetadataPartitionIdent {
 					m.isMetadata = true
-					// UDF Metadata Partition Map:
-					// Common BD-ROM layout encodes the metadata file ICB location as extent_ad
-					// (len=1, loc=<lbn>) at offset 36 from start of the map.
-					if mlen >= 36+8 {
-						extLen := binary.LittleEndian.Uint32(pm[off+36 : off+40])
-						extLoc := binary.LittleEndian.Uint32(pm[off+40 : off+44])
-						if extLen == 1 {
-							m.metadataICBLBN = extLoc
-						} else {
-							// Fallback: interpret extLen as the LBN (seen on some images).
-							m.metadataICBLBN = extLen
-						}
-					}
+					m.partitionNumber = binary.LittleEndian.Uint16(pm[off+38 : off+40])
+					m.metadataICBLBN = binary.LittleEndian.Uint32(pm[off+40 : off+44])
 				}
 			}
 			r.partitionMaps = append(r.partitionMaps, m)
@@ -468,6 +450,33 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 	}
 
 	return nil
+}
+
+func decodeLogicalVolumeContentsUse(contentsUse [16]byte) (lbn uint32, pref uint16, ok bool) {
+	hasData := false
+	for _, b := range contentsUse {
+		if b != 0 {
+			hasData = true
+			break
+		}
+	}
+	if !hasData {
+		return 0, 0, false
+	}
+
+	lbn = binary.LittleEndian.Uint32(contentsUse[8:12])
+	pref = binary.LittleEndian.Uint16(contentsUse[12:14])
+	if lbn == 0 {
+		return 0, pref, false
+	}
+	return lbn, pref, true
+}
+
+func (r *Reader) fileSetDescriptorBlock() (uint32, error) {
+	return r.resolveLBAddr(LBAddr{
+		LogicalBlockNumber:       r.fileSetLocation,
+		PartitionReferenceNumber: r.fileSetPartitionReference,
+	})
 }
 
 func (r *Reader) resolvePartitionBlock(partRef uint16, lbn uint32) (uint32, error) {

--- a/internal/fs/udf/reader.go
+++ b/internal/fs/udf/reader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strings"
 )
@@ -438,6 +439,9 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 			found := false
 			for j, pm2 := range r.partitionMaps {
 				if pm2.kind == partitionMapType1 && pm2.partitionNumber == m.partitionNumber {
+					if j > math.MaxUint16 {
+						return fmt.Errorf("metadata partition map: matching type1 index %d exceeds partition reference range", j)
+					}
 					pref = uint16(j)
 					found = true
 					break

--- a/internal/fs/udf/reader.go
+++ b/internal/fs/udf/reader.go
@@ -21,6 +21,7 @@ type Reader struct {
 	fileSetDesc               *FileSetDescriptor
 	fileSetLocation           uint32
 	fileSetPartitionReference uint16
+	fileSetLocationValid      bool
 
 	metadataFileICB        *LongAD
 	metadataFileAllocDescs []allocationDescriptor
@@ -99,7 +100,7 @@ func (r *Reader) initialize() error {
 
 	// Now read the file set descriptor after we have partition info
 
-	if r.fileSetLocation > 0 {
+	if r.fileSetLocationValid {
 		location, err := r.fileSetDescriptorBlock()
 		if err != nil {
 			return fmt.Errorf("failed to resolve file set descriptor location: %w", err)
@@ -293,6 +294,7 @@ func (r *Reader) readVolumeDescriptorSequence(extent ExtentAD) error {
 			// For now, just store the location
 			r.fileSetLocation = fileSetLocation
 			r.fileSetPartitionReference = fileSetPartitionReference
+			r.fileSetLocationValid = true
 
 		case TagTerminating:
 			// End of sequence
@@ -433,11 +435,16 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 	for _, m := range r.partitionMaps {
 		if m.kind == partitionMapType2 && m.isMetadata {
 			pref := uint16(0)
+			found := false
 			for j, pm2 := range r.partitionMaps {
 				if pm2.kind == partitionMapType1 && pm2.partitionNumber == m.partitionNumber {
 					pref = uint16(j)
+					found = true
 					break
 				}
+			}
+			if !found {
+				return fmt.Errorf("metadata partition map: no type1 partition map found for partition number %d", m.partitionNumber)
 			}
 			icb := LongAD{
 				ExtentLocation: LBAddr{
@@ -460,22 +467,17 @@ func (r *Reader) parsePartitionMaps(pm []byte, n uint32) error {
 }
 
 func decodeLogicalVolumeContentsUse(contentsUse [16]byte) (lbn uint32, pref uint16, ok bool) {
-	hasData := false
-	for _, b := range contentsUse {
-		if b != 0 {
-			hasData = true
-			break
-		}
-	}
-	if !hasData {
+	// LogicalVolumeContentsUse holds a long_ad pointing at the FSD.
+	// Per ECMA-167 4/14.14.1.2, an unused/unrecorded extent is signaled by
+	// ExtentLength == 0, not by LogicalBlockNumber == 0 — LBN 0 is a
+	// legitimate FSD location (e.g. block 0 of a UDF metadata partition).
+	extentLength := binary.LittleEndian.Uint32(contentsUse[0:4]) & 0x3FFFFFFF
+	if extentLength == 0 {
 		return 0, 0, false
 	}
 
 	lbn = binary.LittleEndian.Uint32(contentsUse[4:8])
 	pref = binary.LittleEndian.Uint16(contentsUse[8:10])
-	if lbn == 0 {
-		return 0, pref, false
-	}
 	return lbn, pref, true
 }
 

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -104,13 +104,13 @@ func TestFileSetDescriptorBlockUsesLogicalVolumePartitionReference(t *testing.T)
 
 func TestDecodeLogicalVolumeContentsUseAsLongAD(t *testing.T) {
 	var contentsUse [16]byte
-	// long_ad: ExtentLength at 0:4, LBN at 4:8 of lb_addr (8:12 overall),
-	// partition reference at 12:14, implementation use at 14:16.
+	// long_ad: ExtentLength at 0:4, LBN at 4:8, partition reference at
+	// 8:10, implementation use at 10:16.
 	contentsUse[0] = 0x00
 	contentsUse[1] = 0x08
-	contentsUse[8] = 0x34
-	contentsUse[9] = 0x12
-	contentsUse[12] = 0x02
+	contentsUse[4] = 0x34
+	contentsUse[5] = 0x12
+	contentsUse[8] = 0x02
 
 	lbn, pref, ok := decodeLogicalVolumeContentsUse(contentsUse)
 	if !ok {

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -45,14 +45,16 @@ func TestDecodeString_8BitStopsAtNUL(t *testing.T) {
 func TestParsePartitionMaps_MetadataPartition(t *testing.T) {
 	// Partition map table bytes from a UDF 2.50+ BD-ROM (metadata partition map).
 	pm := []byte{
-		0x01, 0x06, 0x01, 0x00, 0x00, 0x00, // type 1, len 6, volseq=1, part=0
-		0x02, 0x40, 0x00, 0x00, // type 2, len 64, reserved
+		0x01, 0x06, 0x01, 0x00, 0x02, 0x00, // type 1, len 6, volseq=1, part=2
+		0x02, 0x40, // type 2, len 64
+		0x00, 0x00, // reserved
 		0x00, // EntityID flags
 		'*', 'U', 'D', 'F', ' ', 'M', 'e', 't', 'a', 'd', 'a', 't', 'a', ' ', 'P', 'a', 'r', 't', 'i', 't', 'i', 'o', 'n',
 		0x50, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // suffix (opaque)
-		// extent_ad(len=1, loc=0) for metadata file ICB location (common BD-ROM layout)
-		0x01, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00,
+		0x01, 0x00, // volume sequence number
+		0x02, 0x00, // partition number
+		// MetadataFileLocation is a uint32 LBN at offset 40 from the map start.
+		0x78, 0x56, 0x34, 0x12,
 		// remaining fields (not used by go-bdinfo currently)
 		0x3f, 0xca, 0xb9, 0x00,
 		0xff, 0xff, 0xff, 0xff,
@@ -74,11 +76,51 @@ func TestParsePartitionMaps_MetadataPartition(t *testing.T) {
 	if r.metadataFileICB == nil {
 		t.Fatalf("metadataFileICB=nil want non-nil")
 	}
-	if got, want := r.metadataFileICB.ExtentLocation.LogicalBlockNumber, uint32(0); got != want {
+	if got, want := r.metadataFileICB.ExtentLocation.LogicalBlockNumber, uint32(0x12345678); got != want {
 		t.Fatalf("metadataFileICB lbn=%d want %d", got, want)
 	}
 	if got, want := r.metadataFileICB.ExtentLocation.PartitionReferenceNumber, uint16(0); got != want {
 		t.Fatalf("metadataFileICB pref=%d want %d", got, want)
+	}
+}
+
+func TestFileSetDescriptorBlockUsesLogicalVolumePartitionReference(t *testing.T) {
+	r := &Reader{
+		partitionStart:            100,
+		fileSetLocation:           77,
+		fileSetPartitionReference: 1,
+		partitionStarts:           map[uint16]uint32{5: 2000},
+		partitionMaps:             []partitionMap{{kind: partitionMapType1, partitionNumber: 0}, {kind: partitionMapType1, partitionNumber: 5}},
+	}
+
+	got, err := r.fileSetDescriptorBlock()
+	if err != nil {
+		t.Fatalf("fileSetDescriptorBlock err: %v", err)
+	}
+	if want := uint32(2077); got != want {
+		t.Fatalf("fileSetDescriptorBlock=%d want %d", got, want)
+	}
+}
+
+func TestDecodeLogicalVolumeContentsUseAsLongAD(t *testing.T) {
+	var contentsUse [16]byte
+	// long_ad: ExtentLength at 0:4, LBN at 4:8 of lb_addr (8:12 overall),
+	// partition reference at 12:14, implementation use at 14:16.
+	contentsUse[0] = 0x00
+	contentsUse[1] = 0x08
+	contentsUse[8] = 0x34
+	contentsUse[9] = 0x12
+	contentsUse[12] = 0x02
+
+	lbn, pref, ok := decodeLogicalVolumeContentsUse(contentsUse)
+	if !ok {
+		t.Fatalf("decodeLogicalVolumeContentsUse ok=false want true")
+	}
+	if want := uint32(0x1234); lbn != want {
+		t.Fatalf("lbn=%d want %d", lbn, want)
+	}
+	if want := uint16(2); pref != want {
+		t.Fatalf("pref=%d want %d", pref, want)
 	}
 }
 

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -124,6 +124,25 @@ func TestDecodeLogicalVolumeContentsUseAsLongAD(t *testing.T) {
 	}
 }
 
+func TestReadEmbeddedDirectoryDataDecodesUCS2FileIdentifier(t *testing.T) {
+	name := []byte{16, 0, 'B', 0, 'D', 0, 'M', 0, 'V'}
+	data := make([]byte, 48)
+	data[18] = FileCharDirectory
+	data[19] = byte(len(name))
+	copy(data[38:], name)
+
+	dir := &Directory{reader: &Reader{}}
+	if err := dir.readEmbeddedDirectoryData(data); err != nil {
+		t.Fatalf("readEmbeddedDirectoryData err: %v", err)
+	}
+	if len(dir.entries) != 1 {
+		t.Fatalf("entries len=%d want 1", len(dir.entries))
+	}
+	if got, want := dir.getFileName(dir.entries[0]), "BDMV"; got != want {
+		t.Fatalf("dir name=%q want %q", got, want)
+	}
+}
+
 func TestExtentReader_ReadsAcrossExtents(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "udf-extents-*")
 	if err != nil {

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -139,13 +139,14 @@ func TestFileSetDescriptorBlockRoutesThroughMetadataPartition(t *testing.T) {
 	r := &Reader{
 		partitionStart:            100,
 		fileSetLocation:           0,
-		fileSetPartitionReference: 0,
+		fileSetPartitionReference: 1, // must come from the stored reference, not default to 0
 		partitionMaps: []partitionMap{
+			{kind: partitionMapType1, partitionNumber: 9}, // decoy at index 0
 			{kind: partitionMapType2, isMetadata: true, partitionNumber: 1},
 			{kind: partitionMapType1, partitionNumber: 1},
 		},
 		metadataFileAllocDescs: []allocationDescriptor{
-			{pref: 1, lbn: 4, length: 2048},
+			{pref: 2, lbn: 4, length: 2048},
 		},
 	}
 

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -44,8 +44,12 @@ func TestDecodeString_8BitStopsAtNUL(t *testing.T) {
 
 func TestParsePartitionMaps_MetadataPartition(t *testing.T) {
 	// Partition map table bytes from a UDF 2.50+ BD-ROM (metadata partition map).
+	// Two type1 maps precede the metadata map so the test can distinguish
+	// "matched the type1 map for partition 2 at index 1" from "found no
+	// match and defaulted pref to 0" (index 0 is a non-matching partition).
 	pm := []byte{
-		0x01, 0x06, 0x01, 0x00, 0x02, 0x00, // type 1, len 6, volseq=1, part=2
+		0x01, 0x06, 0x01, 0x00, 0x09, 0x00, // type 1, len 6, volseq=1, part=9 (non-matching)
+		0x01, 0x06, 0x01, 0x00, 0x02, 0x00, // type 1, len 6, volseq=1, part=2 (matches metadata map)
 		0x02, 0x40, // type 2, len 64
 		0x00, 0x00, // reserved
 		0x00, // EntityID flags
@@ -64,14 +68,14 @@ func TestParsePartitionMaps_MetadataPartition(t *testing.T) {
 	}
 
 	r := &Reader{}
-	if err := r.parsePartitionMaps(pm, 2); err != nil {
+	if err := r.parsePartitionMaps(pm, 3); err != nil {
 		t.Fatalf("parsePartitionMaps err: %v", err)
 	}
-	if got := len(r.partitionMaps); got != 2 {
-		t.Fatalf("partitionMaps len=%d want 2", got)
+	if got := len(r.partitionMaps); got != 3 {
+		t.Fatalf("partitionMaps len=%d want 3", got)
 	}
-	if !r.partitionMaps[1].isMetadata {
-		t.Fatalf("partitionMaps[1].isMetadata=false want true")
+	if !r.partitionMaps[2].isMetadata {
+		t.Fatalf("partitionMaps[2].isMetadata=false want true")
 	}
 	if r.metadataFileICB == nil {
 		t.Fatalf("metadataFileICB=nil want non-nil")
@@ -79,8 +83,34 @@ func TestParsePartitionMaps_MetadataPartition(t *testing.T) {
 	if got, want := r.metadataFileICB.ExtentLocation.LogicalBlockNumber, uint32(0x12345678); got != want {
 		t.Fatalf("metadataFileICB lbn=%d want %d", got, want)
 	}
-	if got, want := r.metadataFileICB.ExtentLocation.PartitionReferenceNumber, uint16(0); got != want {
+	if got, want := r.metadataFileICB.ExtentLocation.PartitionReferenceNumber, uint16(1); got != want {
 		t.Fatalf("metadataFileICB pref=%d want %d", got, want)
+	}
+}
+
+func TestParsePartitionMaps_MetadataPartitionNoMatchingType1IsError(t *testing.T) {
+	// Same metadata map as above (partition number 2) but with no type1
+	// map at all — must error instead of silently defaulting pref to 0,
+	// which previously could alias the metadata map itself and recurse.
+	pm := []byte{
+		0x02, 0x40, // type 2, len 64
+		0x00, 0x00, // reserved
+		0x00, // EntityID flags
+		'*', 'U', 'D', 'F', ' ', 'M', 'e', 't', 'a', 'd', 'a', 't', 'a', ' ', 'P', 'a', 'r', 't', 'i', 't', 'i', 'o', 'n',
+		0x50, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // suffix (opaque)
+		0x01, 0x00, // volume sequence number
+		0x02, 0x00, // partition number
+		0x78, 0x56, 0x34, 0x12,
+		0x3f, 0xca, 0xb9, 0x00,
+		0xff, 0xff, 0xff, 0xff,
+		0x20, 0x00, 0x00, 0x00,
+		0x20, 0x00, 0x01, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	r := &Reader{}
+	if err := r.parsePartitionMaps(pm, 1); err == nil {
+		t.Fatalf("parsePartitionMaps err=nil want error for unmatched metadata partition number")
 	}
 }
 
@@ -98,6 +128,32 @@ func TestFileSetDescriptorBlockUsesLogicalVolumePartitionReference(t *testing.T)
 		t.Fatalf("fileSetDescriptorBlock err: %v", err)
 	}
 	if want := uint32(2077); got != want {
+		t.Fatalf("fileSetDescriptorBlock=%d want %d", got, want)
+	}
+}
+
+func TestFileSetDescriptorBlockRoutesThroughMetadataPartition(t *testing.T) {
+	// Canonical UDF 2.50 layout: FSD's partition reference points at the
+	// type2 metadata map, whose file entry (pre-populated here to avoid
+	// I/O) has one 2048-byte extent starting at partition block 4.
+	r := &Reader{
+		partitionStart:            100,
+		fileSetLocation:           0,
+		fileSetPartitionReference: 0,
+		partitionMaps: []partitionMap{
+			{kind: partitionMapType2, isMetadata: true, partitionNumber: 1},
+			{kind: partitionMapType1, partitionNumber: 1},
+		},
+		metadataFileAllocDescs: []allocationDescriptor{
+			{pref: 1, lbn: 4, length: 2048},
+		},
+	}
+
+	got, err := r.fileSetDescriptorBlock()
+	if err != nil {
+		t.Fatalf("fileSetDescriptorBlock err: %v", err)
+	}
+	if want := uint32(104); got != want {
 		t.Fatalf("fileSetDescriptorBlock=%d want %d", got, want)
 	}
 }
@@ -120,6 +176,46 @@ func TestDecodeLogicalVolumeContentsUseAsLongAD(t *testing.T) {
 		t.Fatalf("lbn=%d want %d", lbn, want)
 	}
 	if want := uint16(2); pref != want {
+		t.Fatalf("pref=%d want %d", pref, want)
+	}
+}
+
+func TestDecodeLogicalVolumeContentsUse_AllZeroIsUnused(t *testing.T) {
+	var contentsUse [16]byte
+	_, _, ok := decodeLogicalVolumeContentsUse(contentsUse)
+	if ok {
+		t.Fatalf("decodeLogicalVolumeContentsUse ok=true want false for all-zero contentsUse")
+	}
+}
+
+func TestDecodeLogicalVolumeContentsUse_ZeroExtentLengthIsUnused(t *testing.T) {
+	var contentsUse [16]byte
+	// ExtentLength (0:4) is zero but LBN (4:8) is non-zero: still unused
+	// per ECMA-167 4/14.14.1.2 — ExtentLength governs, not LBN.
+	contentsUse[4] = 0x34
+	contentsUse[5] = 0x12
+	_, _, ok := decodeLogicalVolumeContentsUse(contentsUse)
+	if ok {
+		t.Fatalf("decodeLogicalVolumeContentsUse ok=true want false for zero ExtentLength")
+	}
+}
+
+func TestDecodeLogicalVolumeContentsUse_ZeroLBNIsValid(t *testing.T) {
+	var contentsUse [16]byte
+	// Canonical UDF 2.50 metadata-partition FSD: ExtentLength=2048,
+	// LBN=0 (block 0 of the metadata partition), pref=1.
+	contentsUse[0] = 0x00
+	contentsUse[1] = 0x08
+	contentsUse[8] = 0x01
+
+	lbn, pref, ok := decodeLogicalVolumeContentsUse(contentsUse)
+	if !ok {
+		t.Fatalf("decodeLogicalVolumeContentsUse ok=false want true for LBN=0 with non-zero ExtentLength")
+	}
+	if lbn != 0 {
+		t.Fatalf("lbn=%d want 0", lbn)
+	}
+	if want := uint16(1); pref != want {
 		t.Fatalf("pref=%d want %d", pref, want)
 	}
 }


### PR DESCRIPTION
  ## Summary

  Fix UDF 2.50 ISO handling for Blu-ray images that use metadata partitions.

  ## Changes

  - Parse UDF metadata partition maps using the UDF 2.50 layout:
    - metadata identifier via EntityID
    - partition number at offset 38
    - metadata file location as uint32 at offset 40
  - Decode `LogicalVolumeContentsUse` as a `long_ad` when locating the File Set Descriptor.
  - Resolve File Set Descriptor and metadata blocks through partition maps instead of assuming `partitionStart + LBN`.
  - Decode File Identifier names as OSTA Compressed Unicode, including UCS-2 names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDF directory entry filename decoding to correctly interpret Unicode/UCS-2 encoded identifiers.
  * Enhanced File Set descriptor resolution to reliably locate the descriptor across partition layouts, with clearer failure behavior when it can’t be resolved.
  * Refined metadata partition parsing to derive metadata file locations more accurately and avoid incorrect defaults.
* **Tests**
  * Updated metadata partition fixtures/expectations.
  * Added unit coverage for logical-volume contents decoding, File Set descriptor routing, UCS-2 filename decoding, and key error/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->