### PR TITLE
fix: harden AC-3/E-AC-3 frame walk and DiscoverPlaylists size accounting

### DIFF
--- a/internal/bdrom/bdrom.go
+++ b/internal/bdrom/bdrom.go
@@ -474,90 +474,16 @@ func (b *BDROM) ScanMetadata() ScanResult {
 
 // ScanMetadataWithProgress is like ScanMetadata but emits progress events.
 func (b *BDROM) ScanMetadataWithProgress(progress ScanProgressFunc) ScanResult {
-	result := ScanResult{FileErrors: make(map[string]error)}
-	var errMu sync.Mutex
-	var progressMu sync.Mutex
-	emit := func(update ScanProgress) {
-		if progress != nil {
-			progress(update)
-		}
-	}
-
-	clipFiles := orderedStreamClipFiles(b.StreamClipFiles)
-	emit(ScanProgress{Stage: ScanStageClipInfo, Total: len(clipFiles)})
-	var clipDone atomic.Int64
-	runParallel(clipFiles, scanWorkerLimit(len(clipFiles), 0), func(clip *StreamClipFile) error {
-		return clip.Scan()
-	}, func(_ *StreamClipFile) {
-		progressMu.Lock()
-		defer progressMu.Unlock()
-		done := int(clipDone.Add(1))
-		emit(ScanProgress{Stage: ScanStageClipInfo, Completed: done, Total: len(clipFiles)})
-	}, func(clip *StreamClipFile, err error) {
-		errMu.Lock()
-		result.FileErrors[clip.Name] = err
-		errMu.Unlock()
-	})
-
-	for _, streamFile := range b.StreamFiles {
-		ssifName := strings.ToUpper(strings.TrimSuffix(streamFile.Name, ".M2TS") + ".SSIF")
-		if ssif, ok := b.InterleavedFiles[ssifName]; ok {
-			streamFile.InterleavedFile = ssif
-		}
-	}
-
-	playlists := orderedPlaylists(b.PlaylistFiles, b.PlaylistOrder)
-	emit(ScanProgress{Stage: ScanStagePlaylist, Total: len(playlists)})
-	var playlistDone atomic.Int64
-	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
-		return playlist.Scan(b.StreamFiles, b.StreamClipFiles)
-	}, func(_ *PlaylistFile) {
-		progressMu.Lock()
-		defer progressMu.Unlock()
-		done := int(playlistDone.Add(1))
-		emit(ScanProgress{Stage: ScanStagePlaylist, Completed: done, Total: len(playlists)})
-	}, func(playlist *PlaylistFile, err error) {
-		errMu.Lock()
-		result.FileErrors[playlist.Name] = err
-		errMu.Unlock()
-	})
-
-	emit(ScanProgress{Stage: ScanStageInitialize, Total: len(playlists)})
-	var initDone atomic.Int64
-	runParallel(playlists, scanWorkerLimit(len(playlists), 0), func(playlist *PlaylistFile) error {
-		playlist.Initialize()
-		return nil
-	}, func(_ *PlaylistFile) {
-		progressMu.Lock()
-		defer progressMu.Unlock()
-		done := int(initDone.Add(1))
-		emit(ScanProgress{Stage: ScanStageInitialize, Completed: done, Total: len(playlists)})
-	}, nil)
-
-	for _, playlist := range playlists {
-		vidCount := len(playlist.VideoStreams)
-		for _, vs := range playlist.VideoStreams {
-			if !b.Is50Hz && (vs.FrameRate() == stream.FrameRate25 || vs.FrameRate() == stream.FrameRate50) {
-				b.Is50Hz = true
-			}
-			if vidCount > 1 && b.Is3D {
-				if (vs.StreamType == stream.StreamTypeAVCVideo && playlist.MVCBaseViewR) ||
-					(vs.StreamType == stream.StreamTypeMVCVideo && !playlist.MVCBaseViewR) {
-					base := true
-					vs.BaseView = &base
-				} else if vs.StreamType == stream.StreamTypeAVCVideo || vs.StreamType == stream.StreamTypeMVCVideo {
-					base := false
-					vs.BaseView = &base
-				}
-			}
-		}
-	}
-
-	emit(ScanProgress{Stage: ScanStageComplete, Completed: 1, Total: 1})
-	return result
+	return b.scanWithProgress(progress, false)
 }
 
 func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
+	return b.scanWithProgress(progress, true)
+}
+
+// scanWithProgress scans clip info and playlists, optionally scanning M2TS stream
+// files (scanStreams), then applies the shared 50Hz/3D BaseView epilogue.
+func (b *BDROM) scanWithProgress(progress ScanProgressFunc, scanStreams bool) ScanResult {
 	result := ScanResult{FileErrors: make(map[string]error)}
 	var errMu sync.Mutex
 	var progressMu sync.Mutex
@@ -606,57 +532,58 @@ func (b *BDROM) ScanWithProgress(progress ScanProgressFunc) ScanResult {
 		errMu.Unlock()
 	})
 
-	// scan stream files
-	streamFiles := orderedStreamFiles(b.StreamFiles)
-	streamPlaylists := buildStreamPlaylistIndex(playlists)
-	filteredStreamFiles := streamFiles[:0]
-	for _, streamFile := range streamFiles {
-		if len(streamPlaylists[streamFile]) == 0 {
-			continue
-		}
-		filteredStreamFiles = append(filteredStreamFiles, streamFile)
-	}
-	streamFiles = filteredStreamFiles
-	streamBytes := streamFilesTotalSize(streamFiles)
-	emit(ScanProgress{Stage: ScanStageStream, Total: len(streamFiles), TotalBytes: streamBytes})
-	var streamDone atomic.Int64
-	var streamProcessed atomic.Uint64
-	var streamEmitMu sync.Mutex
-	lastStreamEmit := time.Time{}
-	lastStreamBytes := uint64(0)
-	const streamEmitBytes = uint64(4 * 1024 * 1024)
-	const streamEmitInterval = 500 * time.Millisecond
-	emitStream := func(force bool) {
-		streamEmitMu.Lock()
-		defer streamEmitMu.Unlock()
-		processed := streamProcessed.Load()
-		done := int(streamDone.Load())
-		if !force {
-			if processed < streamBytes && processed-lastStreamBytes < streamEmitBytes && (lastStreamEmit.IsZero() || time.Since(lastStreamEmit) < streamEmitInterval) {
-				return
+	if scanStreams {
+		streamFiles := orderedStreamFiles(b.StreamFiles)
+		streamPlaylists := buildStreamPlaylistIndex(playlists)
+		filteredStreamFiles := streamFiles[:0]
+		for _, streamFile := range streamFiles {
+			if len(streamPlaylists[streamFile]) == 0 {
+				continue
 			}
-			lastStreamBytes = processed
-			lastStreamEmit = time.Now()
+			filteredStreamFiles = append(filteredStreamFiles, streamFile)
 		}
-		emit(ScanProgress{Stage: ScanStageStream, Completed: done, Total: len(streamFiles), ProcessedBytes: processed, TotalBytes: streamBytes})
-	}
-	runParallel(streamFiles, scanWorkerLimit(len(streamFiles), streamBytes), func(streamFile *StreamFile) error {
-		return streamFile.ScanWithProgress(streamPlaylists[streamFile], false, func(delta uint64) {
-			if delta == 0 {
-				return
+		streamFiles = filteredStreamFiles
+		streamBytes := streamFilesTotalSize(streamFiles)
+		emit(ScanProgress{Stage: ScanStageStream, Total: len(streamFiles), TotalBytes: streamBytes})
+		var streamDone atomic.Int64
+		var streamProcessed atomic.Uint64
+		var streamEmitMu sync.Mutex
+		lastStreamEmit := time.Time{}
+		lastStreamBytes := uint64(0)
+		const streamEmitBytes = uint64(4 * 1024 * 1024)
+		const streamEmitInterval = 500 * time.Millisecond
+		emitStream := func(force bool) {
+			streamEmitMu.Lock()
+			defer streamEmitMu.Unlock()
+			processed := streamProcessed.Load()
+			done := int(streamDone.Load())
+			if !force {
+				if processed < streamBytes && processed-lastStreamBytes < streamEmitBytes && (lastStreamEmit.IsZero() || time.Since(lastStreamEmit) < streamEmitInterval) {
+					return
+				}
+				lastStreamBytes = processed
+				lastStreamEmit = time.Now()
 			}
-			streamProcessed.Add(delta)
-			emitStream(false)
+			emit(ScanProgress{Stage: ScanStageStream, Completed: done, Total: len(streamFiles), ProcessedBytes: processed, TotalBytes: streamBytes})
+		}
+		runParallel(streamFiles, scanWorkerLimit(len(streamFiles), streamBytes), func(streamFile *StreamFile) error {
+			return streamFile.ScanWithProgress(streamPlaylists[streamFile], false, func(delta uint64) {
+				if delta == 0 {
+					return
+				}
+				streamProcessed.Add(delta)
+				emitStream(false)
+			})
+		}, func(_ *StreamFile) {
+			streamDone.Add(1)
+			emitStream(true)
+		}, func(streamFile *StreamFile, err error) {
+			errMu.Lock()
+			result.FileErrors[streamFile.Name] = err
+			errMu.Unlock()
 		})
-	}, func(_ *StreamFile) {
-		streamDone.Add(1)
-		emitStream(true)
-	}, func(streamFile *StreamFile, err error) {
-		errMu.Lock()
-		result.FileErrors[streamFile.Name] = err
-		errMu.Unlock()
-	})
-	emit(ScanProgress{Stage: ScanStageStream, Completed: len(streamFiles), Total: len(streamFiles), ProcessedBytes: streamProcessed.Load(), TotalBytes: streamBytes})
+		emit(ScanProgress{Stage: ScanStageStream, Completed: len(streamFiles), Total: len(streamFiles), ProcessedBytes: streamProcessed.Load(), TotalBytes: streamBytes})
+	}
 
 	emit(ScanProgress{Stage: ScanStageInitialize, Total: len(playlists)})
 	var initDone atomic.Int64

--- a/internal/bdrom/bdrom_epilogue_test.go
+++ b/internal/bdrom/bdrom_epilogue_test.go
@@ -1,0 +1,56 @@
+package bdrom
+
+import (
+	"testing"
+
+	"github.com/autobrr/go-bdinfo/internal/stream"
+)
+
+// Builds a 3D BDROM where the first playlist makes the disc 50Hz and the second
+// carries the AVC+MVC pair whose BaseView the scan epilogue assigns.
+func testEpilogueBDROM() *BDROM {
+	fiftyHz := &stream.VideoStream{}
+	fiftyHz.StreamType = stream.StreamTypeAVCVideo
+	fiftyHz.SetFrameRate(stream.FrameRate25)
+	plA := &PlaylistFile{Name: "00001.MPLS", VideoStreams: []*stream.VideoStream{fiftyHz}}
+
+	avc := &stream.VideoStream{}
+	avc.StreamType = stream.StreamTypeAVCVideo
+	mvc := &stream.VideoStream{}
+	mvc.StreamType = stream.StreamTypeMVCVideo
+	plB := &PlaylistFile{Name: "00002.MPLS", VideoStreams: []*stream.VideoStream{avc, mvc}}
+
+	return &BDROM{
+		Is3D:             true,
+		PlaylistFiles:    map[string]*PlaylistFile{plA.Name: plA, plB.Name: plB},
+		PlaylistOrder:    []string{plA.Name, plB.Name},
+		StreamClipFiles:  map[string]*StreamClipFile{},
+		StreamFiles:      map[string]*StreamFile{},
+		InterleavedFiles: map[string]*InterleavedFile{},
+	}
+}
+
+// The metadata scan and the full scan must apply the identical 50Hz/BaseView
+// epilogue (upstream BDInfo semantics: `if Is50Hz continue`). The two epilogues
+// were copy-pasted and had already drifted.
+func TestScanEpilogue_MetadataMatchesFullScan(t *testing.T) {
+	metaROM := testEpilogueBDROM()
+	fullROM := testEpilogueBDROM()
+
+	metaROM.ScanMetadata()
+	fullROM.Scan()
+
+	if metaROM.Is50Hz != fullROM.Is50Hz {
+		t.Fatalf("Is50Hz drift: metadata=%v full=%v", metaROM.Is50Hz, fullROM.Is50Hz)
+	}
+	for i := range 2 {
+		meta := metaROM.PlaylistFiles["00002.MPLS"].VideoStreams[i].BaseView
+		full := fullROM.PlaylistFiles["00002.MPLS"].VideoStreams[i].BaseView
+		if (meta == nil) != (full == nil) {
+			t.Fatalf("BaseView drift on stream %d: metadata=%v full=%v", i, meta, full)
+		}
+		if meta != nil && *meta != *full {
+			t.Fatalf("BaseView value drift on stream %d: metadata=%v full=%v", i, *meta, *full)
+		}
+	}
+}

--- a/internal/bdrom/playlist.go
+++ b/internal/bdrom/playlist.go
@@ -127,21 +127,21 @@ func (p *PlaylistFile) FileSize() uint64 {
 	return size
 }
 
-// MainAngleFileSize returns the sum of file sizes for angle-0 clips only, deduplicating
-// loop repetitions. Mirrors TotalSize() but uses filesystem sizes instead of packet counts.
+// MainAngleFileSize returns the sum of file sizes for angle-0 clips only. Because
+// clip.FileSize is the WHOLE .m2ts size, dedup is per physical file (not per clipRefKey):
+// a seamless-branch playlist referencing several segments of one file counts it once.
 // Use as a metadata-only fallback when TotalSize() is zero and no M2TS scan was performed.
 func (p *PlaylistFile) MainAngleFileSize() uint64 {
-	seen := make(map[clipRefKey]struct{})
+	seen := make(map[string]struct{})
 	var size uint64
 	for _, clip := range p.StreamClips {
 		if clip.AngleIndex != 0 {
 			continue
 		}
-		key := newClipRefKey(clip)
-		if _, ok := seen[key]; ok {
+		if _, ok := seen[clip.Name]; ok {
 			continue
 		}
-		seen[key] = struct{}{}
+		seen[clip.Name] = struct{}{}
 		size += clip.FileSize
 	}
 	return size

--- a/internal/bdrom/playlist_loop_size_test.go
+++ b/internal/bdrom/playlist_loop_size_test.go
@@ -78,6 +78,26 @@ func TestPlaylistFile_NonLoopingSizeUnchanged(t *testing.T) {
 	}
 }
 
+// MainAngleFileSize reports whole-file sizes, so multiple segment references into
+// the SAME physical .m2ts (seamless branching) must count that file exactly once —
+// unlike packet-based TotalSize, where distinct segments are genuinely distinct bytes.
+func TestPlaylistFile_MainAngleFileSizeCountsPhysicalFileOnce(t *testing.T) {
+	cfg := settings.Default(t.TempDir())
+	pl := &PlaylistFile{
+		Name:     "00110.MPLS",
+		Settings: cfg,
+		StreamClips: []*StreamClip{
+			{Settings: cfg, AngleIndex: 0, Name: "00110.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, FileSize: 1000},
+			{Settings: cfg, AngleIndex: 0, Name: "00110.M2TS", TimeIn: 20, TimeOut: 30, Length: 10, FileSize: 1000},
+			{Settings: cfg, AngleIndex: 0, Name: "00111.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, FileSize: 300},
+			{Settings: cfg, AngleIndex: 1, Name: "00112.M2TS", TimeIn: 0, TimeOut: 10, Length: 10, FileSize: 400},
+		},
+	}
+	if got, want := pl.MainAngleFileSize(), uint64(1000+300); got != want {
+		t.Errorf("MainAngleFileSize() = %d, want %d (same physical file counted once, other angles excluded)", got, want)
+	}
+}
+
 // Two references to the SAME file but DIFFERENT in/out points are distinct content
 // (not a loop) and must both be counted.
 func TestPlaylistFile_SameFileDifferentSegmentsBothCounted(t *testing.T) {

--- a/internal/codec/ac3.go
+++ b/internal/codec/ac3.go
@@ -92,9 +92,6 @@ func mergeAudioChannelLayouts(layouts ...string) string {
 }
 
 func orderedChannelLayout(seen map[string]bool) string {
-	if len(seen) == 0 {
-		return ""
-	}
 	parts := make([]string, 0, len(seen))
 	for _, ch := range channelLayoutOrder {
 		if seen[ch] {
@@ -110,16 +107,20 @@ func orderedChannelLayout(seen map[string]bool) string {
 
 // ScanAC3 updates audio metadata from the first usable AC-3 or E-AC-3 frames in data.
 //
-// For E-AC-3, the stream can require both an independent core frame and a later
-// dependent frame to expose Atmos/JOC metadata, expanded channel count, and embedded
-// AC3 core details. The scan stops once the stream reaches initialized state.
+// For E-AC-3, Atmos/JOC metadata, expanded channel count, and embedded core details
+// live in a dependent (strmtyp 1) frame that follows the independent frame. The walk
+// therefore continues past an initialized stream, but only onto dependent frames, so
+// no other frame kind can mutate already-initialized metadata.
 func ScanAC3(a *stream.AudioStream, data []byte) {
 	if a.IsInitialized {
 		return
 	}
 	for offset := findAC3Sync(data); offset >= 0 && offset+7 <= len(data); {
+		if a.IsInitialized && !isDependentEAC3Header(data[offset:]) {
+			return
+		}
 		frameSize, ok := scanAC3Frame(a, data[offset:])
-		if ok && a.IsInitialized {
+		if ok && a.IsInitialized && !(a.StreamType == stream.StreamTypeAC3PlusAudio && a.CoreStream == nil) {
 			return
 		}
 
@@ -138,6 +139,16 @@ func ScanAC3(a *stream.AudioStream, data []byte) {
 	}
 }
 
+// isDependentEAC3Header reports whether data starts with a dependent (strmtyp 1)
+// E-AC-3 frame header.
+func isDependentEAC3Header(data []byte) bool {
+	if len(data) < 6 || data[0] != 0x0b || data[1] != 0x77 {
+		return false
+	}
+	bsid := (data[5] & 0xF8) >> 3
+	return bsid > 10 && bsid <= 16 && data[2]>>6 == 1
+}
+
 // scanAC3Frame parses one sync-aligned AC-3 or E-AC-3 frame and returns its byte size.
 // It mutates a only with metadata found inside that frame; ok is false when the
 // frame header is absent, unsupported, or truncated.
@@ -149,7 +160,8 @@ func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
 		return 0, false
 	}
 	frameSizeBytes, ok := ac3FrameSize(data)
-	if !ok {
+	if !ok || frameSizeBytes < 7 {
+		// A frame smaller than its own header (E-AC-3 frmsiz 0/1) is a false sync.
 		return 0, false
 	}
 	if len(data) < frameSizeBytes {
@@ -265,16 +277,22 @@ func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
 			}
 		}
 		if frameType == 1 {
-			a.CoreStream = a.Clone().(*stream.AudioStream)
-			a.CoreStream.StreamType = stream.StreamTypeAC3Audio
+			// Only treat this as an extension of a previously parsed independent
+			// frame; a dependent frame seen first has no core to clone or extend.
+			if secondFrame {
+				a.CoreStream = a.Clone().(*stream.AudioStream)
+				a.CoreStream.StreamType = stream.StreamTypeAC3Audio
+			}
 			if readBool() {
 				chanmap := read(16)
-				a.ChannelCount = a.CoreStream.ChannelCount
-				a.ChannelCount += ac3ChanMap(uint16(chanmap))
-				if layout := eac3ChannelMapLayout(uint16(chanmap)); layout != "" {
-					a.ChannelLayoutText = mergeAudioChannelLayouts(a.CoreStream.ChannelLayoutText, layout)
+				if a.CoreStream != nil {
+					a.ChannelCount = a.CoreStream.ChannelCount
+					a.ChannelCount += ac3ChanMap(uint16(chanmap))
+					if layout := eac3ChannelMapLayout(uint16(chanmap)); layout != "" {
+						a.ChannelLayoutText = mergeAudioChannelLayouts(a.CoreStream.ChannelLayoutText, layout)
+					}
+					lfeOn = uint64(a.CoreStream.LFE)
 				}
-				lfeOn = uint64(a.CoreStream.LFE)
 			}
 		}
 

--- a/internal/codec/ac3.go
+++ b/internal/codec/ac3.go
@@ -108,20 +108,36 @@ func orderedChannelLayout(seen map[string]bool) string {
 // ScanAC3 updates audio metadata from the first usable AC-3 or E-AC-3 frames in data.
 //
 // For E-AC-3, Atmos/JOC metadata, expanded channel count, and embedded core details
-// live in a dependent (strmtyp 1) frame that follows the independent frame. The walk
-// therefore continues past an initialized stream, but only onto dependent frames, so
-// no other frame kind can mutate already-initialized metadata.
+// live in dependent (strmtyp 1) frames that follow the independent frame — up to
+// eight per access unit. The walk therefore merges every consecutive dependent frame
+// after the independent one and stops at the next independent frame, so no other
+// frame kind can mutate already-initialized metadata. Dependent frames seen before
+// any independent frame (a mid-access-unit start) are skipped, not parsed: their
+// extension data is meaningless without the frame they extend.
 func ScanAC3(a *stream.AudioStream, data []byte) {
 	if a.IsInitialized {
 		return
 	}
+	sawIndependent := false
 	for offset := findAC3Sync(data); offset >= 0 && offset+7 <= len(data); {
-		if a.IsInitialized && !isDependentEAC3Header(data[offset:]) {
+		dependent := isDependentEAC3Header(data[offset:])
+		if a.IsInitialized && !dependent {
 			return
 		}
-		frameSize, ok := scanAC3Frame(a, data[offset:])
-		if ok && a.IsInitialized && !(a.StreamType == stream.StreamTypeAC3PlusAudio && a.CoreStream == nil) {
-			return
+
+		var frameSize int
+		var ok bool
+		if dependent && !sawIndependent {
+			frameSize, ok = ac3FrameSize(data[offset:])
+			ok = ok && frameSize >= 7
+		} else {
+			frameSize, ok = scanAC3Frame(a, data[offset:], sawIndependent)
+			if ok && !dependent {
+				sawIndependent = true
+			}
+			if ok && a.IsInitialized && a.StreamType != stream.StreamTypeAC3PlusAudio {
+				return
+			}
 		}
 
 		next := offset + 2
@@ -151,8 +167,10 @@ func isDependentEAC3Header(data []byte) bool {
 
 // scanAC3Frame parses one sync-aligned AC-3 or E-AC-3 frame and returns its byte size.
 // It mutates a only with metadata found inside that frame; ok is false when the
-// frame header is absent, unsupported, or truncated.
-func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
+// frame header is absent, unsupported, or truncated. sawIndependent reports whether
+// an earlier frame in this walk carried the stream's core/independent data — only
+// then may a dependent frame snapshot an embedded core and extend it.
+func scanAC3Frame(a *stream.AudioStream, data []byte, sawIndependent bool) (int, bool) {
 	if len(data) < 7 {
 		return 0, false
 	}
@@ -169,7 +187,6 @@ func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
 	}
 	frameData := data[:frameSizeBytes]
 
-	secondFrame := a.ChannelCount > 0
 	bsidPeek := (frameData[5] & 0xF8) >> 3
 
 	br := buffer.NewBitReader(frameData)
@@ -277,19 +294,18 @@ func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
 			}
 		}
 		if frameType == 1 {
-			// Only treat this as an extension of a previously parsed independent
-			// frame; a dependent frame seen first has no core to clone or extend.
-			if secondFrame {
+			// The embedded core is a snapshot of the independent-frame state,
+			// taken once: later dependent frames extend a, not the core.
+			if sawIndependent && a.CoreStream == nil {
 				a.CoreStream = a.Clone().(*stream.AudioStream)
 				a.CoreStream.StreamType = stream.StreamTypeAC3Audio
 			}
 			if readBool() {
 				chanmap := read(16)
 				if a.CoreStream != nil {
-					a.ChannelCount = a.CoreStream.ChannelCount
 					a.ChannelCount += ac3ChanMap(uint16(chanmap))
 					if layout := eac3ChannelMapLayout(uint16(chanmap)); layout != "" {
-						a.ChannelLayoutText = mergeAudioChannelLayouts(a.CoreStream.ChannelLayoutText, layout)
+						a.ChannelLayoutText = mergeAudioChannelLayouts(a.ChannelLayoutText, layout)
 					}
 					lfeOn = uint64(a.CoreStream.LFE)
 				}
@@ -391,13 +407,13 @@ func scanAC3Frame(a *stream.AudioStream, data []byte) (int, bool) {
 			a.DialNorm = -int(dialNorm)
 		case a.StreamType == stream.StreamTypeAC3Audio:
 			a.DialNorm = -int(dialNorm)
-		case a.StreamType == stream.StreamTypeAC3PlusAudio && secondFrame:
+		case a.StreamType == stream.StreamTypeAC3PlusAudio && sawIndependent:
 			a.DialNorm = -int(dialNormExt)
 		}
 	}
 
 	a.IsVBR = false
-	if a.StreamType == stream.StreamTypeAC3PlusAudio && bsid == 6 && !secondFrame {
+	if a.StreamType == stream.StreamTypeAC3PlusAudio && bsid == 6 && !sawIndependent {
 		a.IsInitialized = false
 	} else {
 		a.IsInitialized = true

--- a/internal/codec/ac3_test.go
+++ b/internal/codec/ac3_test.go
@@ -53,35 +53,41 @@ func testAC3PlusCoreFrame() []byte {
 	return w.pad(2304)
 }
 
-func testAC3PlusDependentJOCFrame() []byte {
+func testAC3PlusDependentFrame(substreamID uint64, chanmap uint64, joc bool) []byte {
 	var w testBitWriter
 	w.write(0x0b77, 16)
-	w.write(1, 2)       // dependent stream
-	w.write(0, 3)       // substreamid
-	w.write(1151, 11)   // 2304 bytes
-	w.write(0, 2)       // 48 kHz
-	w.write(3, 2)       // six blocks in this parser's BDInfo-compatible mapping
-	w.write(7, 3)       // 3/2
-	w.write(1, 1)       // lfeon
-	w.write(16, 5)      // bsid
-	w.write(25, 5)      // dialnorm
-	w.write(0, 1)       // compre
-	w.write(1, 1)       // chanmape
-	w.write(0x0010, 16) // Tfl/Tfr
+	w.write(1, 2)           // dependent stream
+	w.write(substreamID, 3) // substreamid
+	w.write(1151, 11)       // 2304 bytes
+	w.write(0, 2)           // 48 kHz
+	w.write(3, 2)           // six blocks in this parser's BDInfo-compatible mapping
+	w.write(7, 3)           // 3/2
+	w.write(1, 1)           // lfeon
+	w.write(16, 5)          // bsid
+	w.write(25, 5)          // dialnorm
+	w.write(0, 1)           // compre
+	w.write(1, 1)           // chanmape
+	w.write(chanmap, 16)
 
-	w.write(0x5838, 16) // emdf sync
-	w.write(8, 16)      // emdf_container_size
-	w.write(0, 2)       // emdf_version
-	w.write(0, 3)
-	w.write(0, 5)  // first payload id
-	w.write(14, 5) // JOC payload id
-	writeTestEmdfPayloadConfig(&w)
-	w.write(0, 8) // payload size
-	w.write(0, 1) // skipped payload bit
-	writeTestEmdfPayloadConfig(&w)
-	w.write(0, 12)
-	w.write(1, 6) // joc_num_objects_bits
+	if joc {
+		w.write(0x5838, 16) // emdf sync
+		w.write(8, 16)      // emdf_container_size
+		w.write(0, 2)       // emdf_version
+		w.write(0, 3)
+		w.write(0, 5)  // first payload id
+		w.write(14, 5) // JOC payload id
+		writeTestEmdfPayloadConfig(&w)
+		w.write(0, 8) // payload size
+		w.write(0, 1) // skipped payload bit
+		writeTestEmdfPayloadConfig(&w)
+		w.write(0, 12)
+		w.write(1, 6) // joc_num_objects_bits
+	}
 	return w.pad(2304)
+}
+
+func testAC3PlusDependentJOCFrame() []byte {
+	return testAC3PlusDependentFrame(0, 0x0010, true) // Tfl/Tfr + JOC
 }
 
 func testAC3PlusIndependentFrame() []byte {
@@ -101,21 +107,7 @@ func testAC3PlusIndependentFrame() []byte {
 }
 
 func testAC3PlusDependentFrameNoJOC() []byte {
-	var w testBitWriter
-	w.write(0x0b77, 16)
-	w.write(1, 2)       // dependent stream
-	w.write(0, 3)       // substreamid
-	w.write(1151, 11)   // 2304 bytes
-	w.write(0, 2)       // 48 kHz
-	w.write(3, 2)       // six blocks in this parser's BDInfo-compatible mapping
-	w.write(7, 3)       // 3/2
-	w.write(1, 1)       // lfeon
-	w.write(16, 5)      // bsid
-	w.write(25, 5)      // dialnorm
-	w.write(0, 1)       // compre
-	w.write(1, 1)       // chanmape
-	w.write(0x0010, 16) // Tfl/Tfr
-	return w.pad(2304)
+	return testAC3PlusDependentFrame(0, 0x0010, false) // Tfl/Tfr, no JOC
 }
 
 func writeTestEmdfPayloadConfig(w *testBitWriter) {
@@ -212,18 +204,69 @@ func TestScanAC3_AC3PlusIndependentOnlyStopsAtFirstFrame(t *testing.T) {
 	}
 }
 
-// A dependent frame with no preceding independent frame (buffer starts mid
-// access-unit) must not fabricate an empty core: that renders a height-only
-// "0.0.2" channel description.
+// E-AC-3 allows up to eight dependent substreams per independent frame; JOC and
+// channel extensions may live in a later dependent, so the walk must merge every
+// consecutive dependent frame, not stop at the first one.
+func TestScanAC3_AC3PlusMultipleDependentSubstreams(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	data := append(testAC3PlusIndependentFrame(), testAC3PlusDependentFrame(0, 0x0200, false)...) // Lb/Rb
+	data = append(data, testAC3PlusDependentFrame(1, 0x0010, true)...)                            // Tfl/Tfr + JOC
+
+	ScanAC3(a, data)
+
+	if !a.HasExtensions {
+		t.Fatal("expected Atmos extension from second dependent frame")
+	}
+	if a.ChannelLayoutText != "L R C LFE Ls Rs Lb Rb Tfl Tfr" {
+		t.Fatalf("channel layout got %q want merged layout from both dependents", a.ChannelLayoutText)
+	}
+	if a.ChannelCount != 9 {
+		t.Fatalf("channel count got %d want 9 (5 core + 2 + 2)", a.ChannelCount)
+	}
+	if a.CoreStream == nil || a.CoreStream.ChannelCount != 5 {
+		t.Fatalf("core stream must be the independent-frame snapshot, got %+v", a.CoreStream)
+	}
+}
+
+// Dependent frames with no preceding independent frame (buffer starts mid
+// access-unit) carry extension data that is meaningless on its own: they must be
+// skipped without initializing the stream or fabricating an embedded core.
 func TestScanAC3_DependentFrameFirstDoesNotFabricateCore(t *testing.T) {
 	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
-	ScanAC3(a, testAC3PlusDependentJOCFrame())
+	data := append(testAC3PlusDependentJOCFrame(), testAC3PlusDependentFrame(1, 0x0010, true)...)
+	ScanAC3(a, data)
 
 	if a.CoreStream != nil {
 		t.Fatal("unexpected core stream cloned from uninitialized state")
 	}
-	if a.ChannelDescription() != "5.1" {
-		t.Fatalf("channel description got %q want 5.1 from the frame's own channel mode", a.ChannelDescription())
+	if a.IsInitialized {
+		t.Fatal("leading dependent frames must not initialize the stream")
+	}
+	if a.HasExtensions {
+		t.Fatal("unexpected Atmos extension from orphan dependent frames")
+	}
+}
+
+// A mid-access-unit start must recover: skip the leading dependent, then parse
+// the independent frame and its dependents normally.
+func TestScanAC3_DependentFrameFirstRecoversAtIndependent(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	data := append(testAC3PlusDependentJOCFrame(), testAC3PlusIndependentFrame()...)
+	data = append(data, testAC3PlusDependentJOCFrame()...)
+
+	ScanAC3(a, data)
+
+	if !a.IsInitialized {
+		t.Fatal("stream not initialized")
+	}
+	if !a.HasExtensions {
+		t.Fatal("expected Atmos extension from the complete access unit")
+	}
+	if a.ChannelDescription() != "5.1.2" {
+		t.Fatalf("channel description got %q want 5.1.2", a.ChannelDescription())
+	}
+	if a.CoreStream == nil {
+		t.Fatal("expected embedded core from independent frame")
 	}
 }
 
@@ -233,7 +276,7 @@ func TestScanAC3_FrameBoundaryPreventsTrailingJOCDetection(t *testing.T) {
 
 	trailingJOC := testAC3PlusDependentJOCFrame()
 	data := append(testAC3PlusDependentFrameNoJOC(), trailingJOC...)
-	frameSize, ok := scanAC3Frame(a, data)
+	frameSize, ok := scanAC3Frame(a, data, true)
 
 	if !ok {
 		t.Fatal("expected dependent frame to parse")
@@ -261,7 +304,7 @@ func TestScanAC3_RejectsTruncatedFrame(t *testing.T) {
 	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
 	data := testAC3PlusCoreFrame()[:128]
 
-	if frameSize, ok := scanAC3Frame(a, data); ok || frameSize != 0 {
+	if frameSize, ok := scanAC3Frame(a, data, false); ok || frameSize != 0 {
 		t.Fatalf("scanAC3Frame truncated frame got size=%d ok=%v", frameSize, ok)
 	}
 }

--- a/internal/codec/ac3_test.go
+++ b/internal/codec/ac3_test.go
@@ -84,6 +84,22 @@ func testAC3PlusDependentJOCFrame() []byte {
 	return w.pad(2304)
 }
 
+func testAC3PlusIndependentFrame() []byte {
+	var w testBitWriter
+	w.write(0x0b77, 16)
+	w.write(0, 2)     // independent stream
+	w.write(0, 3)     // substreamid
+	w.write(1151, 11) // 2304 bytes
+	w.write(0, 2)     // 48 kHz
+	w.write(3, 2)     // six blocks in this parser's BDInfo-compatible mapping
+	w.write(7, 3)     // 3/2
+	w.write(1, 1)     // lfeon
+	w.write(16, 5)    // bsid
+	w.write(25, 5)    // dialnorm
+	w.write(0, 1)     // compre
+	return w.pad(2304)
+}
+
 func testAC3PlusDependentFrameNoJOC() []byte {
 	var w testBitWriter
 	w.write(0x0b77, 16)
@@ -145,6 +161,72 @@ func TestScanAC3_AC3PlusAtmosDependentFrame(t *testing.T) {
 	}
 }
 
+// Real DD+ Atmos frame order: the independent frame is bsid-16 (not a bsid-6 AC-3
+// core), so it initializes the stream on the first parse; the dependent JOC frame
+// that follows must still be parsed or Atmos is silently dropped.
+func TestScanAC3_AC3PlusAtmosRealFrameOrder(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	data := append(testAC3PlusIndependentFrame(), testAC3PlusDependentJOCFrame()...)
+
+	ScanAC3(a, data)
+
+	if !a.IsInitialized {
+		t.Fatal("stream not initialized")
+	}
+	if !a.HasExtensions {
+		t.Fatal("expected Atmos extension from dependent JOC frame")
+	}
+	if a.ChannelLayoutText != "L R C LFE Ls Rs Tfl Tfr" {
+		t.Fatalf("channel layout got %q want Tfl/Tfr height layout", a.ChannelLayoutText)
+	}
+	if a.ChannelDescription() != "5.1.2" {
+		t.Fatalf("channel description got %q want 5.1.2", a.ChannelDescription())
+	}
+	if a.BitRate != 1152000 {
+		t.Fatalf("bitrate got %d want 1152000", a.BitRate)
+	}
+	if a.CoreStream == nil {
+		t.Fatal("expected embedded core from independent frame")
+	}
+}
+
+// A plain DD+ stream (independent frames only, no dependent substream) must stop at
+// the first frame exactly as before: no DialNorm from a second frame, no core.
+func TestScanAC3_AC3PlusIndependentOnlyStopsAtFirstFrame(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	data := append(testAC3PlusIndependentFrame(), testAC3PlusIndependentFrame()...)
+
+	ScanAC3(a, data)
+
+	if !a.IsInitialized {
+		t.Fatal("stream not initialized")
+	}
+	if a.DialNorm != 0 {
+		t.Fatalf("DialNorm got %d want 0 (second independent frame must not be parsed)", a.DialNorm)
+	}
+	if a.CoreStream != nil {
+		t.Fatal("unexpected core stream for independent-only DD+")
+	}
+	if a.ChannelDescription() != "5.1" {
+		t.Fatalf("channel description got %q want 5.1", a.ChannelDescription())
+	}
+}
+
+// A dependent frame with no preceding independent frame (buffer starts mid
+// access-unit) must not fabricate an empty core: that renders a height-only
+// "0.0.2" channel description.
+func TestScanAC3_DependentFrameFirstDoesNotFabricateCore(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	ScanAC3(a, testAC3PlusDependentJOCFrame())
+
+	if a.CoreStream != nil {
+		t.Fatal("unexpected core stream cloned from uninitialized state")
+	}
+	if a.ChannelDescription() != "5.1" {
+		t.Fatalf("channel description got %q want 5.1 from the frame's own channel mode", a.ChannelDescription())
+	}
+}
+
 func TestScanAC3_FrameBoundaryPreventsTrailingJOCDetection(t *testing.T) {
 	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
 	ScanAC3(a, testAC3PlusCoreFrame())
@@ -161,6 +243,17 @@ func TestScanAC3_FrameBoundaryPreventsTrailingJOCDetection(t *testing.T) {
 	}
 	if a.HasExtensions {
 		t.Fatal("unexpected Atmos extension from trailing frame bytes")
+	}
+}
+
+func TestScanAC3_ShortEAC3FrameDoesNotPanic(t *testing.T) {
+	a := &stream.AudioStream{Stream: stream.Stream{StreamType: stream.StreamTypeAC3PlusAudio}}
+	// E-AC-3 header with frmsiz 0: claimed frame size (2 bytes) is shorter than
+	// the header fields the parser reads. Seen as a false 0x0b77 sync in payload.
+	ScanAC3(a, []byte{0x0b, 0x77, 0x00, 0x00, 0x00, 0x58, 0x00})
+
+	if a.IsInitialized {
+		t.Fatal("garbage short frame must not initialize stream")
 	}
 }
 

--- a/internal/codec/dtshd.go
+++ b/internal/codec/dtshd.go
@@ -2,6 +2,7 @@ package codec
 
 import (
 	"encoding/binary"
+	"strings"
 
 	"github.com/autobrr/go-bdinfo/internal/buffer"
 	"github.com/autobrr/go-bdinfo/internal/stream"
@@ -279,65 +280,26 @@ func ScanDTSHD(a *stream.AudioStream, data []byte, fallbackBitrate int64) {
 	}
 }
 
+// dtsHDSpeakerActivityLayouts maps DTS-HD ExSS speaker activity mask bits (LSB first)
+// to MediaInfo-compatible speaker labels.
+var dtsHDSpeakerActivityLayouts = []string{
+	"C", "L R", "Ls Rs", "LFE", "Cs", "Lh Rh", "Lsr Rsr", "Ch",
+	"Oh", "Lc Rc", "Lw Rw", "Lss Rss", "LFE2", "Lhs Rhs", "Chr", "Lhr Rhr",
+}
+
 // dtsHDSpeakerActivityMaskChannelLayout converts a DTS-HD ExSS speaker activity mask
 // into MediaInfo-compatible speaker labels.
 func dtsHDSpeakerActivityMaskChannelLayout(mask uint16) string {
 	if mask == 1 {
 		return "M"
 	}
-	out := ""
-	if mask&0x0001 != 0 {
-		out += " C"
+	parts := make([]string, 0, 16)
+	for i, layout := range dtsHDSpeakerActivityLayouts {
+		if mask&(1<<i) != 0 {
+			parts = append(parts, layout)
+		}
 	}
-	if mask&0x0002 != 0 {
-		out += " L R"
-	}
-	if mask&0x0004 != 0 {
-		out += " Ls Rs"
-	}
-	if mask&0x0008 != 0 {
-		out += " LFE"
-	}
-	if mask&0x0010 != 0 {
-		out += " Cs"
-	}
-	if mask&0x0020 != 0 {
-		out += " Lh Rh"
-	}
-	if mask&0x0040 != 0 {
-		out += " Lsr Rsr"
-	}
-	if mask&0x0080 != 0 {
-		out += " Ch"
-	}
-	if mask&0x0100 != 0 {
-		out += " Oh"
-	}
-	if mask&0x0200 != 0 {
-		out += " Lc Rc"
-	}
-	if mask&0x0400 != 0 {
-		out += " Lw Rw"
-	}
-	if mask&0x0800 != 0 {
-		out += " Lss Rss"
-	}
-	if mask&0x1000 != 0 {
-		out += " LFE2"
-	}
-	if mask&0x2000 != 0 {
-		out += " Lhs Rhs"
-	}
-	if mask&0x4000 != 0 {
-		out += " Chr"
-	}
-	if mask&0x8000 != 0 {
-		out += " Lhr Rhr"
-	}
-	if out == "" {
-		return ""
-	}
-	return out[1:]
+	return strings.Join(parts, " ")
 }
 
 func detectDTSX(data []byte) bool {

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -555,21 +555,19 @@ func ConvertSampleRate(rate SampleRate) int {
 }
 
 func (a *AudioStream) ChannelDescription() string {
-	if description := immersiveChannelDescription(a.ChannelLayoutText); description != "" {
-		return description
-	}
-
-	description := ""
-	if a.ChannelCount > 0 {
-		description += fmt.Sprintf("%d.%d", a.ChannelCount, a.LFE)
-	} else {
-		switch a.ChannelLayout {
-		case ChannelLayoutMono:
-			description += "1.0"
-		case ChannelLayoutStereo:
-			description += "2.0"
-		case ChannelLayoutMulti:
-			description += "5.1"
+	description := immersiveChannelDescription(a.ChannelLayoutText)
+	if description == "" {
+		if a.ChannelCount > 0 {
+			description += fmt.Sprintf("%d.%d", a.ChannelCount, a.LFE)
+		} else {
+			switch a.ChannelLayout {
+			case ChannelLayoutMono:
+				description += "1.0"
+			case ChannelLayoutStereo:
+				description += "2.0"
+			case ChannelLayoutMulti:
+				description += "5.1"
+			}
 		}
 	}
 

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -26,6 +26,20 @@ func TestAudioStreamChannelDescription_DTSHeightLayout(t *testing.T) {
 	}
 }
 
+func TestAudioStreamChannelDescription_HeightLayoutKeepsExtendedSuffix(t *testing.T) {
+	a := &AudioStream{
+		Stream:            Stream{StreamType: StreamTypeDTSHDMasterAudio},
+		AudioMode:         AudioModeExtended,
+		ChannelCount:      7,
+		LFE:               1,
+		ChannelLayoutText: "L R C LFE Ls Rs Lh Rh",
+	}
+
+	if got := a.ChannelDescription(); got != "5.1.2-ES" {
+		t.Fatalf("ChannelDescription()=%q want 5.1.2-ES", got)
+	}
+}
+
 func TestAudioStreamChannelDescription_NonHeightLayoutUsesLegacyCount(t *testing.T) {
 	a := &AudioStream{
 		ChannelCount:      7,

--- a/pkg/bdinfo/bdinfo.go
+++ b/pkg/bdinfo/bdinfo.go
@@ -129,6 +129,13 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 		return Result{}, err
 	}
 
+	start := time.Now()
+	emit(options.OnProgress, ProgressEvent{
+		Stage:      StageStarting,
+		Path:       options.Path,
+		OccurredAt: time.Now(),
+	})
+
 	cfg := toInternalSettings(options.Settings)
 	rom, err := bdrom.New(options.Path, cfg)
 	if err != nil {
@@ -153,7 +160,11 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 		return Result{}, err
 	}
 
-	start := time.Now()
+	emit(options.OnProgress, ProgressEvent{
+		Stage:      StageScanning,
+		Path:       options.Path,
+		OccurredAt: time.Now(),
+	})
 	var scan bdrom.ScanResult
 	if options.OnProgress != nil {
 		scan = rom.ScanMetadataWithProgress(func(update bdrom.ScanProgress) {
@@ -187,11 +198,20 @@ func DiscoverPlaylists(ctx context.Context, options Options) (Result, error) {
 	}
 
 	playlists := orderedPlaylists(rom)
-	return Result{
+	result := Result{
 		Disc:      buildDiscInfo(rom),
 		Playlists: buildPlaylistInfo(playlists, true),
 		Scan:      buildScanInfo(scan),
-	}, nil
+	}
+
+	emit(options.OnProgress, ProgressEvent{
+		Stage:      StageDone,
+		Path:       options.Path,
+		Elapsed:    time.Since(start),
+		OccurredAt: time.Now(),
+	})
+
+	return result, nil
 }
 
 // Run scans one path and returns structured output plus report content.

--- a/pkg/bdinfo/bdinfo_test.go
+++ b/pkg/bdinfo/bdinfo_test.go
@@ -1,0 +1,35 @@
+package bdinfo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// DiscoverPlaylists must bracket its progress stream like Run does:
+// StageStarting first, StageDone last.
+func TestDiscoverPlaylists_EmitsStartingAndDone(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"BDMV/PLAYLIST", "BDMV/CLIPINF"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var stages []Stage
+	_, err := DiscoverPlaylists(context.Background(), Options{
+		Path:       root,
+		OnProgress: func(e ProgressEvent) { stages = append(stages, e.Stage) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(stages) == 0 || stages[0] != StageStarting {
+		t.Fatalf("stages = %v, want StageStarting first", stages)
+	}
+	if stages[len(stages)-1] != StageDone {
+		t.Fatalf("stages = %v, want StageDone last", stages)
+	}
+}


### PR DESCRIPTION
Fixes the verified findings from the `v0.3.1..main` audit of the #24/#25 changes: a latent panic on short E-AC-3 false-sync frames, E-AC-3 Atmos/JOC silently dropped for real-order DD+ streams (independent bsid-16 frame first — the existing test only covered an artificial bsid-6-core-first order), a fabricated empty core when a dependent frame arrives first, and `DiscoverPlaylists` sizes inflated 3–4× on seamless-branch playlists because `MainAngleFileSize` counted the whole `.m2ts` once per segment reference. Also collapses the copy-pasted metadata/full scan fork (whose 50Hz/3D BaseView epilogues had already drifted), keeps the -EX/-ES suffix on immersive channel descriptions, and brackets `DiscoverPlaylists` progress with starting/scanning/done stages.

Every fix landed test-first with a failing repro. Re-verified against the real disc library: the fixed binary is byte-identical to current main on all 5 curated discs (incl. UHD), and the Naked Gun `00110.MPLS` metadata size drops from ×4.398 inflated to the physical file size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced playlist discovery progress with explicit “starting” and “scanning” stages, plus elapsed-time reporting on completion.

- **Bug Fixes**
  - Improved scan behavior: metadata-only scans now skip stream processing while keeping results consistent with full scans (including epilogue/50Hz and BaseView).
  - Corrected playlist file size accounting to count shared physical `.m2ts` files once.
  - Improved AC-3/E-AC-3 and DTS-HD speaker/channel layout parsing, including Atmos/JOC and height/immersive channel descriptions.

- **Tests**
  - Added coverage for epilogue parity, stream size deduplication, Atmos frame ordering, and safe handling of short/invalid E-AC-3 inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->