### PR TITLE
fix(udf): skip deleted file identifier descriptors

### DIFF
--- a/internal/fs/udf/file.go
+++ b/internal/fs/udf/file.go
@@ -500,8 +500,10 @@ func (d *Directory) readDirectoryData(ad allocationDescriptor) error {
 			fid.fileName = d.reader.decodeString(nameData)
 		}
 
-		// Store the FID
-		d.entries = append(d.entries, fid)
+		// Store the FID; skip deleted entries like DiscUtils does
+		if fid.FileCharacteristics&FileCharDeleted == 0 {
+			d.entries = append(d.entries, fid)
+		}
 
 		// Calculate total FID size (must be 4-byte aligned)
 		fidSize := uint32(38) + uint32(fid.LengthOfImplementationUse) + uint32(fid.LengthOfFileIdentifier)
@@ -869,8 +871,10 @@ func (d *Directory) readEmbeddedDirectoryData(data []byte) error {
 			fid.fileName = d.reader.decodeString(nameData)
 		}
 
-		// Store the FID
-		d.entries = append(d.entries, fid)
+		// Store the FID; skip deleted entries like DiscUtils does
+		if fid.FileCharacteristics&FileCharDeleted == 0 {
+			d.entries = append(d.entries, fid)
+		}
 
 		// Calculate total FID size (must be 4-byte aligned)
 		fidSize := uint32(38) + uint32(fid.LengthOfImplementationUse) + uint32(fid.LengthOfFileIdentifier)

--- a/internal/fs/udf/udf_test.go
+++ b/internal/fs/udf/udf_test.go
@@ -276,3 +276,26 @@ func TestExtentReader_ReadsAcrossExtents(t *testing.T) {
 		t.Fatalf("data mismatch: got len=%d want len=%d", len(got), len(want))
 	}
 }
+
+func TestDirectoryEntriesSkipDeletedFIDs(t *testing.T) {
+	fid := func(chars byte, name string) []byte {
+		b := make([]byte, 38)
+		b[18] = chars
+		nameData := append([]byte{8}, name...)
+		b[19] = byte(len(nameData))
+		b = append(b, nameData...)
+		for len(b)%4 != 0 {
+			b = append(b, 0)
+		}
+		return b
+	}
+	data := append(fid(0, "KEEP.MPL"), fid(FileCharDeleted, "GONE.MPL")...)
+
+	d := &Directory{reader: &Reader{}}
+	if err := d.readEmbeddedDirectoryData(data); err != nil {
+		t.Fatalf("readEmbeddedDirectoryData: %v", err)
+	}
+	if len(d.entries) != 1 || d.getFileName(d.entries[0]) != "KEEP.MPL" {
+		t.Fatalf("entries=%v, want only KEEP.MPL", d.entries)
+	}
+}


### PR DESCRIPTION
DiscUtils — the reference BDInfo's UDF layer — skips directory entries with the deleted bit set; our reader kept them, so a disc with deleted FIDs would list ghost files. Filter at parse time, where both the extent and embedded parsers feed all consumers. Surfaced while investigating #29 (no behavior change on pressed discs; verified against the Britney Spears ISO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted directory entries are no longer displayed or included in directory listings.
  * Directory contents now consistently exclude deleted files, including embedded directory data.

* **Tests**
  * Added coverage to verify that valid entries remain visible while deleted entries are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->